### PR TITLE
Component separation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -X=main.version={{ .Version }}
 
 release:
   prerelease: auto

--- a/app/app.go
+++ b/app/app.go
@@ -62,7 +62,7 @@ type App struct {
 	unsubscribe <-chan plexer.Unsubscribe
 }
 
-func New(q chan<- struct{}, errs <-chan plexer.Error, msgs <-chan plexer.Message, subs <-chan plexer.Subscriber, unsubs <-chan plexer.Unsubscribe) (*App, error) {
+func New(bufferSize int, q chan<- struct{}, errs <-chan plexer.Error, msgs <-chan plexer.Message, subs <-chan plexer.Subscriber, unsubs <-chan plexer.Unsubscribe) (*App, error) {
 
 	width, height, err := windowSize()
 	if err != nil {
@@ -76,7 +76,7 @@ func New(q chan<- struct{}, errs <-chan plexer.Error, msgs <-chan plexer.Message
 
 		views: map[int]tea.Model{
 			welcomeView: welcome.New(width, height),
-			logTailView: pager.New(width, height), // have this pre-initialized as it will be need no matter what
+			logTailView: pager.New(width, height, bufferSize), // have this pre-initialized as it will be need no matter what
 		},
 
 		width:  width,

--- a/app/app.go
+++ b/app/app.go
@@ -207,14 +207,20 @@ func (app *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, formatter.RequestView(index))
 			app.state = formatView
 
+		// propagate event to formatter and request to format
+		// previous log line
 		case key.Matches(msg, app.keys.Up) && app.hasInput:
 			cmds = append(cmds, formatter.RequestUp())
 			app.ignoreKey = true
 
+		// propagate event to formatter and request to format
+		// next log line
 		case key.Matches(msg, app.keys.Down) && app.hasInput:
 			cmds = append(cmds, formatter.RequestDown())
 			app.ignoreKey = true
 
+		// terminate formatting view and propagate event to formatter,
+		// reinstate tailView as view for app to render
 		case key.Matches(msg, app.keys.Exit):
 			app.awaitInput = false
 			app.input.Blur()

--- a/app/binding.go
+++ b/app/binding.go
@@ -5,12 +5,13 @@ import (
 )
 
 type bindings struct {
-	Up    key.Binding
-	Down  key.Binding
-	Input key.Binding
-	Exit  key.Binding
-	Enter key.Binding
-	Quit  key.Binding
+	Up     key.Binding
+	Down   key.Binding
+	Input  key.Binding
+	Filter key.Binding
+	Exit   key.Binding
+	Enter  key.Binding
+	Quit   key.Binding
 }
 
 func (b bindings) ShortHelp() []key.Binding {
@@ -33,6 +34,9 @@ var defaultBindings = bindings{
 	),
 	Input: key.NewBinding(
 		key.WithKeys(":"),
+	),
+	Filter: key.NewBinding(
+		key.WithKeys("ctrl+f"),
 	),
 	Enter: key.NewBinding(
 		key.WithKeys("enter"),

--- a/app/binding.go
+++ b/app/binding.go
@@ -8,7 +8,6 @@ import (
 type bindings struct {
 	Up   key.Binding
 	Down key.Binding
-	// View key.Binding
 	Help key.Binding
 	Quit key.Binding
 }
@@ -38,8 +37,8 @@ var defaultBindings = bindings{
 		key.WithHelp("?", "toggle help"),
 	),
 	Quit: key.NewBinding(
-		key.WithKeys("q", "ctrl+c"),
-		key.WithHelp("q", "exit scotty"),
+		key.WithKeys("ctrl+c"),
+		key.WithHelp("ctrl+c", "exit scotty"),
 	),
 }
 

--- a/app/binding.go
+++ b/app/binding.go
@@ -5,20 +5,21 @@ import (
 )
 
 type bindings struct {
-	Up   key.Binding
-	Down key.Binding
-	Help key.Binding
-	Quit key.Binding
+	Up    key.Binding
+	Down  key.Binding
+	Input key.Binding
+	Exit  key.Binding
+	Quit  key.Binding
 }
 
 func (b bindings) ShortHelp() []key.Binding {
-	return []key.Binding{b.Help, b.Quit}
+	return []key.Binding{b.Quit}
 }
 
 func (b bindings) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{b.Up, b.Down},
-		{b.Help, b.Quit},
+		{b.Quit},
 	}
 }
 
@@ -31,9 +32,12 @@ var defaultBindings = bindings{
 		key.WithKeys("down", "j"),
 		key.WithHelp("↓/j", "move down"),
 	),
-	Help: key.NewBinding(
-		key.WithKeys("?"),
-		key.WithHelp("?", "toggle help"),
+	Input: key.NewBinding(
+		key.WithKeys(":"),
+	),
+	Exit: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithKeys("q"),
 	),
 	Quit: key.NewBinding(
 		key.WithKeys("ctrl+c"),

--- a/app/binding.go
+++ b/app/binding.go
@@ -9,6 +9,7 @@ type bindings struct {
 	Down  key.Binding
 	Input key.Binding
 	Exit  key.Binding
+	Enter key.Binding
 	Quit  key.Binding
 }
 
@@ -26,14 +27,15 @@ func (b bindings) FullHelp() [][]key.Binding {
 var defaultBindings = bindings{
 	Up: key.NewBinding(
 		key.WithKeys("up", "k"),
-		key.WithHelp("↑/k", "move up"),
 	),
 	Down: key.NewBinding(
 		key.WithKeys("down", "j"),
-		key.WithHelp("↓/j", "move down"),
 	),
 	Input: key.NewBinding(
 		key.WithKeys(":"),
+	),
+	Enter: key.NewBinding(
+		key.WithKeys("enter"),
 	),
 	Exit: key.NewBinding(
 		key.WithKeys("esc"),

--- a/app/binding.go
+++ b/app/binding.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"github.com/charmbracelet/bubbles/key"
-	tea "github.com/charmbracelet/bubbletea"
 )
 
 type bindings struct {
@@ -40,17 +39,4 @@ var defaultBindings = bindings{
 		key.WithKeys("ctrl+c"),
 		key.WithHelp("ctrl+c", "exit scotty"),
 	),
-}
-
-func (app *App) resolveKey(msg tea.KeyMsg) tea.Cmd {
-
-	switch true {
-	case key.Matches(msg, app.keys.Quit):
-		return tea.Quit
-	case key.Matches(msg, app.keys.Help):
-		app.help.ShowAll = !app.help.ShowAll
-
-	}
-
-	return nil
 }

--- a/app/component/formatter/formatter.go
+++ b/app/component/formatter/formatter.go
@@ -115,8 +115,6 @@ func New(width, height int, buffer *ring.Buffer) *Model {
 	view.MouseWheelEnabled = true
 	view.Style = modelStyle.Width(w)
 
-	debug.Print("[model.New] width: %d (%d), height: %d (%d)\n", w, view.Width, h, view.Height)
-
 	return &Model{
 		buffer: buffer,
 		writer: bytes.Buffer{},

--- a/app/component/formatter/formatter.go
+++ b/app/component/formatter/formatter.go
@@ -1,0 +1,465 @@
+package formatter
+
+import (
+	"bytes"
+	"strconv"
+
+	"github.com/KonstantinGasser/scotty/app/styles"
+	"github.com/KonstantinGasser/scotty/debug"
+	"github.com/KonstantinGasser/scotty/ring"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	bottomSectionHeight = 1
+	inputSectionHeight  = 1
+
+	borderMargin = 1
+
+	// wow literally no idea why this number hence
+	// the variable name - if you get why tell me and
+	// pls open a PR..else pls don't change it
+	magicNumber = 2
+
+	awaitInput = iota + 1
+	hasInput
+)
+
+var (
+	modelStyle = lipgloss.NewStyle().Padding(0, 1)
+
+	inputStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(styles.DefaultColor.Border)
+)
+
+type subscriber struct {
+	label string
+	color lipgloss.Color
+}
+
+// Model implements the tea.Model interface.
+// Furthermore, Model allows to tail logs.
+// Model does not not store the logs its only
+// porose is it to display them.
+type Model struct {
+	buffer *ring.Buffer
+	writer bytes.Buffer
+
+	beams map[string]lipgloss.Color
+
+	// stores the length of the longest stream
+	// label in order to align the start of the logs
+	maxLabelLength int
+
+	// underlying model which handles
+	// scrolling and rendering of the logs
+	view viewport.Model
+
+	// available tty width and height
+	// updates if changes
+	width, height int
+
+	// relativeIndex represents the requested index
+	// on the current page. Whichever item == index
+	// is highlighted and formatted. Note relativeIndex
+	// is the relative index to the page. In order
+	// to get the index of the element within the
+	// buffer one must add the offsetStart to the
+	// relativeIndex to get the absolute index.
+	relativeIndex int
+
+	// absoluteIndex refers to the actual index in the
+	// buffer which is currently formatted
+	absoluteIndex int
+
+	// offsetStart if used when paging through the logs
+	// and formatting log lines. It refers to the index
+	// with which the model starts (first log of the page)
+	offsetStart int
+
+	// pageSize refers to the number of items currently
+	// visible in the view - line wraps are not included
+	// an item which takes up two lines counts as one
+	pageSize int
+
+	// awaitInput indicated if ECS is pressed.
+	// if awaitInput == false the input for commands
+	// is focused else moved out of focus
+	awaitInput bool
+
+	// input is the input field to select
+	// an index to format and input further
+	// commands
+	input textinput.Model
+
+	// some characters inputted we don't want to
+	// propagate down to the textinput.Model
+	// as they are treated as regular chars
+	// and displayed as value - as such indicated if
+	// propagation should be ignored
+	ignoreInput bool
+}
+
+func New(width, height int, buffer *ring.Buffer) *Model {
+	w, h := width-borderMargin, height-bottomSectionHeight-inputSectionHeight-magicNumber
+
+	view := viewport.New(w, h)
+	view.Height = h
+	view.Width = w
+	view.MouseWheelEnabled = true
+	view.Style = modelStyle.Width(w)
+
+	debug.Print("[model.New] width: %d (%d), height: %d (%d)\n", w, view.Width, h, view.Height)
+
+	input := textinput.New()
+	input.Placeholder = "line number (use k/j to move and ESC/q to exit)"
+	input.Prompt = ":"
+
+	return &Model{
+		buffer: buffer,
+		writer: bytes.Buffer{},
+
+		beams:          map[string]lipgloss.Color{},
+		maxLabelLength: 0,
+		view:           view,
+		width:          w,
+		height:         h,
+		awaitInput:     false,
+		relativeIndex:  -1,
+		input:          input,
+	}
+}
+
+func (model *Model) Init() tea.Cmd {
+	return nil
+}
+
+func (model *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+
+	var (
+		cmds []tea.Cmd
+		cmd  tea.Cmd
+	)
+
+	switch msg := msg.(type) {
+	case tea.MouseMsg:
+		model.view, cmd = model.view.Update(msg)
+		cmds = append(cmds, cmd)
+	case tea.KeyMsg:
+		switch msg.String() {
+		// triggers the parsing mode of logs. Has no
+		// effect while in parsing mode (awaitInput == true)
+		case ":":
+			model.awaitInput = true
+
+			// the char ":" is not a cmd for the textinput.Model
+			// and if passed to the update func of the model is
+			// added to the input - which is want we don't want
+			model.ignoreInput = true
+			model.input.Focus()
+
+		case "enter":
+			if !model.awaitInput {
+				break
+			}
+
+			value := model.input.Value()
+			index, err := strconv.Atoi(value)
+			if err != nil {
+				debug.Print("input %q is not numeric. Type the index of the line you want to parse", value)
+				break
+			}
+
+			model.initFormattingMode(index)
+
+			model.updatePage(
+				model.absoluteIndex,
+				ring.WithInlineFormatting(model.width, model.absoluteIndex),
+				ring.WithLineWrap(model.width),
+			)
+			model.view.GotoTop()
+
+			model.input.Blur()
+			model.input.Reset()
+
+		// exits the parsing mode. Has no effect
+		// while not in parsing mode (awaitInput == false)
+		case "esc", "q":
+			if !model.awaitInput {
+				break
+			}
+
+			model.resetFormattingMode()
+
+			// width, height, err := styles.WindowSize()
+			// if err != nil {
+			// 	debug.Print("[tea.KeyMsg(esc)] unable to get tty width and height: %w\n", err)
+			// }
+
+			// model.setDimensions(
+			// 	width,
+			// 	height,
+			// )
+
+			// again the width of the log view changes on
+			// exit as such we need to force a rerender
+			// in order to fix the line wraps of each log
+			// contents, _ := model.peekBuffer(
+			// 	model.height,
+			// 	ring.WithLineWrap(model.width),
+			// )
+			model.writer.Reset()
+			model.view.SetContent("") // unset content
+			// model.view.SetContent(contents)
+			// model.view.GotoBottom()
+
+		// selects the previous log line to be parsed
+		// and displayed. Input ignores when relativeIndex <= 0
+		case "k":
+
+			if model.absoluteIndex == 0 {
+				break
+			}
+
+			model.relativeIndex--
+			model.absoluteIndex--
+
+			// requested index to format is outside (above)
+			// the current view as such we need to shift the
+			// content of the view up. For scrolling up we
+			// only show the next upper element not an entire
+			// new page like we do when scrolling down.
+			if model.relativeIndex < 0 {
+
+				model.previousPage(
+					ring.WithInlineFormatting(model.width, model.absoluteIndex),
+					ring.WithLineWrap(model.width),
+				)
+
+				break
+			}
+
+			model.updatePage(
+				model.absoluteIndex,
+				ring.WithInlineFormatting(model.width, model.absoluteIndex),
+				ring.WithLineWrap(model.width),
+			)
+
+			// for this key stroke we don't need the msg any other where
+			// and we putted to the input model the stork is registered
+			// which we don't want
+			return model, tea.Batch(cmds...)
+
+		// selects the next log line to be parsed and
+		// displayed. Input ignored when relativeIndex >= buffer.cap
+		case "j":
+			model.relativeIndex++ // index of the within the current page
+			model.absoluteIndex++ // overall index of the selected item in the buffer
+
+			// nil items in the buffer indicated that the buffer is not full
+			// and the requested index exists but has not been written to yet.
+			// Just means user wanted a log that has not been beamed yet.
+			if model.buffer.Nil(model.absoluteIndex) {
+				// well showing nothing is not cool
+				// compensate to last working index
+				model.absoluteIndex--
+				model.relativeIndex--
+
+				model.updatePage(
+					model.absoluteIndex,
+					ring.WithInlineFormatting(model.width, model.absoluteIndex),
+					ring.WithLineWrap(model.width),
+				)
+				break
+			}
+
+			// check if the requested log line is out of
+			// the view (not included in the previous render)
+			// if so we need to adjust the page/go to the next
+			// page an rerender the view again
+			if model.relativeIndex >= model.pageSize {
+
+				model.nextPage(
+					ring.WithInlineFormatting(model.width, model.absoluteIndex),
+					ring.WithLineWrap(model.width),
+				)
+
+				break
+			}
+
+			// render logs starting from the offset
+			// till offset+height. The returned
+			// lines indicate how many items are included
+			// in the render (hard to tell solely based on the string
+			// from the model.writer)
+			model.updatePage(
+				model.absoluteIndex,
+				ring.WithInlineFormatting(model.width, model.absoluteIndex),
+				ring.WithLineWrap(model.width),
+			)
+
+			// for this key stroke we don't need the msg any other where
+			// and we putted to the input model the stork is registered
+			// which we don't want
+			return model, tea.Batch(cmds...)
+		}
+
+	// event dispatched from bubbletea when the screen size changes.
+	// We need to update the model and model.view width and height.
+	// However, if the parsing mode is on the width is only 2/3
+	// of the available screen size.
+	case tea.WindowSizeMsg:
+
+		model.setDimensions(
+			msg.Width,
+			msg.Height,
+		)
+
+		if model.awaitInput && model.relativeIndex >= 0 {
+
+			model.updatePage(
+				model.absoluteIndex,
+				ring.WithInlineFormatting(model.width, model.absoluteIndex),
+				ring.WithLineWrap(model.width),
+			)
+
+			break
+		}
+
+		model.updatePage(
+			model.absoluteIndex,
+			ring.WithInlineFormatting(model.width, model.absoluteIndex),
+			ring.WithLineWrap(model.width),
+		)
+		model.view.GotoBottom()
+
+	}
+
+	// propagate event to child models.
+	model.view, cmd = model.view.Update(msg)
+	cmds = append(cmds, cmd)
+
+	// only there to avoid certain chars to be used as
+	// input for the input field.
+	// chars include: "j", "k"
+	if !model.ignoreInput {
+		model.input, cmd = model.input.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+	// ignoring input is only valid for one pass
+	// revert it before the next pass
+	model.ignoreInput = false
+
+	return model, tea.Batch(cmds...)
+}
+
+func (model *Model) View() string {
+	return lipgloss.JoinVertical(lipgloss.Left,
+		model.view.View(),
+		model.input.View(),
+	)
+}
+
+// previousPage renders the current window shifted up by 1
+// and selects the relativeIndex of zero.
+func (model *Model) previousPage(opts ...func(int, []byte) []byte) {
+
+	if model.offsetStart == 0 {
+		return
+	}
+
+	model.relativeIndex = 0
+	model.offsetStart--
+	if model.offsetStart < 0 {
+		model.offsetStart = 0
+	}
+
+	contents, pageSize := model.offsetBuffer(
+		model.offsetStart,
+		model.height,
+		ring.WithInlineFormatting(model.width, model.absoluteIndex),
+		ring.WithLineWrap(model.width),
+	)
+	model.writer.Reset()
+	model.pageSize = pageSize
+	model.view.SetContent(contents)
+}
+
+// updatePage requests the same offset window from the buffer
+// however with a different line marked as selected
+func (model *Model) updatePage(selected int, opts ...func(int, []byte) []byte) {
+
+	contents, pageSize := model.offsetBuffer(
+		model.offsetStart,
+		model.height,
+		opts...,
+	)
+	model.writer.Reset()
+	model.pageSize = pageSize
+
+	model.view.SetContent(contents)
+}
+
+// nextPage "scrolls" the buffer down by one page defined bei the current viewport height.
+// The relativeIndex referring to the line in the current window selected is set to zero
+// again.
+func (model *Model) nextPage(opts ...func(int, []byte) []byte) {
+
+	model.offsetStart += model.relativeIndex
+	// reset relativeIndex since its relative to
+	// the current page. When the page changes
+	// the relative index is 0
+	model.relativeIndex = 0
+
+	contents, pageSize := model.offsetBuffer(
+		model.offsetStart,
+		model.height,
+		opts...,
+	)
+	model.writer.Reset()
+
+	model.pageSize = pageSize
+
+	model.view.SetContent(contents)
+}
+
+func (model Model) offsetBuffer(start, end int, opts ...func(int, []byte) []byte) (string, int) {
+
+	pageSize, err := model.buffer.Offset(
+		&model.writer,
+		start,
+		end,
+		opts...,
+	)
+	if err != nil {
+		debug.Debug(err.Error())
+		return "", pageSize
+	}
+
+	return model.writer.String(), pageSize
+}
+
+func (model *Model) setDimensions(width, height int) {
+	model.width, model.height = width-borderMargin, height-bottomSectionHeight-inputSectionHeight-magicNumber
+	model.view.Width, model.view.Height = model.width, model.height
+}
+
+func (model *Model) initFormattingMode(offset int) {
+	model.offsetStart = offset
+	model.absoluteIndex = model.offsetStart
+	model.relativeIndex = 0
+}
+
+func (model *Model) resetFormattingMode() {
+	model.awaitInput = false
+	model.offsetStart = -1
+	model.relativeIndex = -1
+	model.absoluteIndex = -1
+
+	model.input.Reset()
+	model.input.Blur()
+}

--- a/app/component/pager/footer.go
+++ b/app/component/pager/footer.go
@@ -118,6 +118,7 @@ func (f *footer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "enter":
 			f.isFormatMode = true
+
 		// invoked by parent model when leaving
 		// formatting mode thus we want to reset
 		// values used to show hidden notifications

--- a/app/component/pager/footer.go
+++ b/app/component/pager/footer.go
@@ -121,7 +121,7 @@ func (f *footer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// invoked by parent model when leaving
 		// formatting mode thus we want to reset
 		// values used to show hidden notifications
-		case "esc":
+		case "esc", "q":
 			f.isFormatMode = false
 			for i := range f.streams {
 				f.streams[i].hasNewMessages = false

--- a/app/component/pager/pager.go
+++ b/app/component/pager/pager.go
@@ -77,8 +77,6 @@ func New(width, height int, buffer *ring.Buffer) *Model {
 	view.MouseWheelEnabled = true
 	view.Style = pagerStyle.Width(w)
 
-	debug.Print("[model.New] width: %d (%d), height: %d (%d)\n", w, view.Width, h, view.Height)
-
 	input := textinput.New()
 	input.Placeholder = "line number (use k/j to move and ESC/q to exit)"
 	input.Prompt = ":"

--- a/app/component/pager/pager.go
+++ b/app/component/pager/pager.go
@@ -108,7 +108,7 @@ type Pager struct {
 	footer tea.Model
 }
 
-func New(width, height int) *Pager {
+func New(width, height, bufferSize int) *Pager {
 	w, h := width-borderMargin, height-bottomSectionHeight-inputSectionHeight-magicNumber
 
 	view := viewport.New(w, h)
@@ -124,7 +124,7 @@ func New(width, height int) *Pager {
 	input.Prompt = ":"
 
 	return &Pager{
-		buffer: ring.New(uint32(12)),
+		buffer: ring.New(uint32(bufferSize)),
 		writer: bytes.Buffer{},
 
 		beams:          map[string]lipgloss.Color{},

--- a/app/component/pager/pager.go
+++ b/app/component/pager/pager.go
@@ -146,7 +146,6 @@ func (model *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		model.writer.Reset()
 		model.view.SetContent(contents)
 		model.view.GotoBottom()
-		debug.Print("got a message in pager\n")
 	}
 
 	// propagate event to child models.

--- a/app/component/pager/pager.go
+++ b/app/component/pager/pager.go
@@ -2,7 +2,6 @@ package pager
 
 import (
 	"bytes"
-	"strconv"
 	"strings"
 
 	"github.com/KonstantinGasser/scotty/app/styles"
@@ -43,12 +42,12 @@ type subscriber struct {
 	color lipgloss.Color
 }
 
-// Pager implements the tea.Model interface.
-// Furthermore, Pager allows to tail logs.
-// Pager does not not store the logs its only
+// Model implements the tea.Model interface.
+// Furthermore, Model allows to tail logs.
+// Model does not not store the logs its only
 // porose is it to display them.
-type Pager struct {
-	buffer ring.Buffer
+type Model struct {
+	buffer *ring.Buffer
 	writer bytes.Buffer
 
 	beams map[string]lipgloss.Color
@@ -65,19 +64,6 @@ type Pager struct {
 	// updates if changes
 	width, height int
 
-	// relativeIndex represents the requested index
-	// on the current page. Whichever item == index
-	// is highlighted and formatted. Note relativeIndex
-	// is the relative index to the page. In order
-	// to get the index of the element within the
-	// buffer one must add the offsetStart to the
-	// relativeIndex to get the absolute index.
-	relativeIndex int
-
-	// absoluteIndex refers to the actual index in the
-	// buffer which is currently formatted
-	absoluteIndex int
-
 	// offsetStart if used when paging through the logs
 	// and formatting log lines. It refers to the index
 	// with which the pager starts (first log of the page)
@@ -87,28 +73,9 @@ type Pager struct {
 	// visible in the view - line wraps are not included
 	// an item which takes up two lines counts as one
 	pageSize int
-
-	// awaitInput indicated if ECS is pressed.
-	// if awaitInput == false the input for commands
-	// is focused else moved out of focus
-	awaitInput bool
-
-	// input is the input field to select
-	// an index to format and input further
-	// commands
-	input textinput.Model
-
-	// some characters inputted we don't want to
-	// propagate down to the textinput.Model
-	// as they are treated as regular chars
-	// and displayed as value - as such indicated if
-	// propagation should be ignored
-	ignoreInput bool
-
-	footer tea.Model
 }
 
-func New(width, height, bufferSize int) *Pager {
+func New(width, height int, buffer *ring.Buffer) *Model {
 	w, h := width-borderMargin, height-bottomSectionHeight-inputSectionHeight-magicNumber
 
 	view := viewport.New(w, h)
@@ -117,14 +84,14 @@ func New(width, height, bufferSize int) *Pager {
 	view.MouseWheelEnabled = true
 	view.Style = pagerStyle.Width(w)
 
-	debug.Print("[pager.New] width: %d (%d), height: %d (%d)\n", w, view.Width, h, view.Height)
+	debug.Print("[model.New] width: %d (%d), height: %d (%d)\n", w, view.Width, h, view.Height)
 
 	input := textinput.New()
 	input.Placeholder = "line number (use k/j to move and ESC/q to exit)"
 	input.Prompt = ":"
 
-	return &Pager{
-		buffer: ring.New(uint32(bufferSize)),
+	return &Model{
+		buffer: buffer,
 		writer: bytes.Buffer{},
 
 		beams:          map[string]lipgloss.Color{},
@@ -132,18 +99,14 @@ func New(width, height, bufferSize int) *Pager {
 		view:           view,
 		width:          w,
 		height:         h,
-		awaitInput:     false,
-		relativeIndex:  -1,
-		footer:         newFooter(w, h),
-		input:          input,
 	}
 }
 
-func (pager *Pager) Init() tea.Cmd {
+func (model *Model) Init() tea.Cmd {
 	return nil
 }
 
-func (pager *Pager) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (model *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	var (
 		cmds []tea.Cmd
@@ -152,189 +115,28 @@ func (pager *Pager) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.MouseMsg:
-		pager.view, cmd = pager.view.Update(msg)
+		model.view, cmd = model.view.Update(msg)
 		cmds = append(cmds, cmd)
 	case tea.KeyMsg:
-		switch msg.String() {
-		// triggers the parsing mode of logs. Has no
-		// effect while in parsing mode (awaitInput == true)
-		case ":":
-			pager.awaitInput = true
-
-			// the char ":" is not a cmd for the textinput.Model
-			// and if passed to the update func of the model is
-			// added to the input - which is want we don't want
-			pager.ignoreInput = true
-			pager.input.Focus()
-
-		case "enter":
-			if !pager.awaitInput {
-				break
-			}
-
-			value := pager.input.Value()
-			index, err := strconv.Atoi(value)
-			if err != nil {
-				debug.Print("input %q is not numeric. Type the index of the line you want to parse", value)
-				break
-			}
-
-			pager.initFormattingMode(index)
-
-			pager.updatePage(
-				pager.absoluteIndex,
-				ring.WithInlineFormatting(pager.width, pager.absoluteIndex),
-				ring.WithLineWrap(pager.width),
-			)
-			pager.view.GotoTop()
-
-			pager.input.Blur()
-			pager.input.Reset()
-
-		// exits the parsing mode. Has no effect
-		// while not in parsing mode (awaitInput == false)
-		case "esc", "q":
-			if !pager.awaitInput {
-				break
-			}
-
-			pager.resetFormattingMode()
-
-			width, height, err := styles.WindowSize()
-			if err != nil {
-				debug.Print("[tea.KeyMsg(esc)] unable to get tty width and height: %w\n", err)
-			}
-
-			pager.setDimensions(
-				width,
-				height,
-			)
-
-			// again the width of the log view changes on
-			// exit as such we need to force a rerender
-			// in order to fix the line wraps of each log
-			contents, _ := pager.peekBuffer(
-				pager.height,
-				ring.WithLineWrap(pager.width),
-			)
-			pager.writer.Reset()
-			pager.view.SetContent(contents)
-			pager.view.GotoBottom()
-
-		// selects the previous log line to be parsed
-		// and displayed. Input ignores when relativeIndex <= 0
-		case "k":
-
-			if pager.absoluteIndex == 0 {
-				break
-			}
-
-			pager.relativeIndex--
-			pager.absoluteIndex--
-
-			// requested index to format is outside (above)
-			// the current view as such we need to shift the
-			// content of the view up. For scrolling up we
-			// only show the next upper element not an entire
-			// new page like we do when scrolling down.
-			if pager.relativeIndex < 0 {
-
-				pager.previousPage(
-					ring.WithInlineFormatting(pager.width, pager.absoluteIndex),
-					ring.WithLineWrap(pager.width),
-				)
-
-				break
-			}
-
-			pager.updatePage(
-				pager.absoluteIndex,
-			)
-
-			// for this key stroke we don't need the msg any other where
-			// and we putted to the input model the stork is registered
-			// which we don't want
-			return pager, tea.Batch(cmds...)
-
-		// selects the next log line to be parsed and
-		// displayed. Input ignored when relativeIndex >= buffer.cap
-		case "j":
-			pager.relativeIndex++ // index of the within the current page
-			pager.absoluteIndex++ // overall index of the selected item in the buffer
-
-			// nil items in the buffer indicated that the buffer is not full
-			// and the requested index exists but has not been written to yet.
-			// Just means user wanted a log that has not been beamed yet.
-			if pager.buffer.Nil(pager.absoluteIndex) {
-				// well showing nothing is not cool
-				// compensate to last working index
-				pager.absoluteIndex--
-				pager.relativeIndex--
-
-				pager.updatePage(
-					pager.absoluteIndex,
-				)
-				break
-			}
-
-			// check if the requested log line is out of
-			// the view (not included in the previous render)
-			// if so we need to adjust the page/go to the next
-			// page an rerender the view again
-			if pager.relativeIndex >= pager.pageSize {
-
-				pager.nextPage(
-					ring.WithInlineFormatting(pager.width, pager.absoluteIndex),
-					ring.WithLineWrap(pager.width),
-				)
-
-				break
-			}
-
-			// render logs starting from the offset
-			// till offset+height. The returned
-			// lines indicate how many items are included
-			// in the render (hard to tell solely based on the string
-			// from the pager.writer)
-			pager.updatePage(
-				pager.absoluteIndex,
-			)
-
-			// for this key stroke we don't need the msg any other where
-			// and we putted to the input model the stork is registered
-			// which we don't want
-			return pager, tea.Batch(cmds...)
-		}
 
 	// event dispatched from bubbletea when the screen size changes.
-	// We need to update the pager and pager.view width and height.
+	// We need to update the pager and model.view width and height.
 	// However, if the parsing mode is on the width is only 2/3
 	// of the available screen size.
 	case tea.WindowSizeMsg:
 
-		pager.setDimensions(
+		model.setDimensions(
 			msg.Width,
 			msg.Height,
 		)
 
-		if pager.awaitInput && pager.relativeIndex >= 0 {
-
-			pager.updatePage(
-				pager.absoluteIndex,
-				ring.WithInlineFormatting(pager.width, pager.absoluteIndex),
-				ring.WithLineWrap(pager.width),
-			)
-
-			break
-		}
-
-		contents, _ := pager.peekBuffer(
-			pager.height,
-			ring.WithLineWrap(pager.width),
+		contents, _ := model.peekBuffer(
+			model.height,
+			ring.WithLineWrap(model.width),
 		)
-		pager.writer.Reset()
-		pager.view.SetContent(contents)
-		pager.view.GotoBottom()
+		model.writer.Reset()
+		model.view.SetContent(contents)
+		model.view.GotoBottom()
 
 	// event dispatched each time a beam disconnects from scotty.
 	// The message itself is the label of the stream which
@@ -342,63 +144,63 @@ func (pager *Pager) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// length of the longest stream label in order to maintain
 	// pretty indention for logging the logs with the label prefix
 	case plexer.Unsubscribe:
-		// we only need to reassign the max value
-		// if the current max is disconnecting
-		if len(msg) >= pager.maxLabelLength {
-			max := 0
-			for label := range pager.beams {
-				if len(label) > max && label != string(msg) {
-					max = len(label)
-				}
-			}
-			pager.maxLabelLength = max
-		}
+		// // we only need to reassign the max value
+		// // if the current max is disconnecting
+		// if len(msg) >= model.maxLabelLength {
+		// 	max := 0
+		// 	for label := range model.beams {
+		// 		if len(label) > max && label != string(msg) {
+		// 			max = len(label)
+		// 		}
+		// 	}
+		// 	model.maxLabelLength = max
+		// }
 
 	// event dispatched each time a new stream connects to
 	// the multiplexer. on-event we need to update the footer
 	// model with the new stream information as well as update
-	// the Pagers state. The Pager keeps track of connected beams
+	// the Models state. The Model keeps track of connected beams
 	// however only cares about the color to use when rendering the logs.
-	// Pager will ensure that the color for the printed logs of a stream
+	// Model will ensure that the color for the printed logs of a stream
 	// are matching the color information in the footer
 	case plexer.Subscriber:
 
-		// update max label length for indenting
-		// while displaying logs
-		if len(msg) > pager.maxLabelLength {
-			pager.maxLabelLength = len(msg)
-		}
+		// // update max label length for indenting
+		// // while displaying logs
+		// if len(msg) > model.maxLabelLength {
+		// 	model.maxLabelLength = len(msg)
+		// }
 
-		label := string(msg)
+		// label := string(msg)
 
-		if _, ok := pager.beams[label]; !ok {
-			color, _ := styles.RandColor()
-			pager.beams[label] = color
+		// if _, ok := model.beams[label]; !ok {
+		// 	color, _ := styles.RandColor()
+		// 	model.beams[label] = color
 
-			pager.footer, _ = pager.footer.Update(subscriber{
-				label: label,
-				color: color,
-			})
-		}
+		// 	model.footer, _ = model.footer.Update(subscriber{
+		// 		label: label,
+		// 		color: color,
+		// 	})
+		// }
 
-		pager.footer, _ = pager.footer.Update(subscriber{
-			label: label,
-			color: pager.beams[label],
-		})
+		// model.footer, _ = model.footer.Update(subscriber{
+		// 	label: label,
+		// 	color: model.beams[label],
+		// })
 
-		return pager, tea.Batch(cmds...)
+		// return pager, tea.Batch(cmds...)
 
 	// event dispatched by the multiplexer each time a client/stream
 	// sends a log linen.
-	// The Pager needs to add the ansi color code stored for the stream
+	// The Model needs to add the ansi color code stored for the stream
 	// to the dispatched message before adding the data to the ring buffer.
-	// Once added to the ring buffer the Pager queries for the latest N
+	// Once added to the ring buffer the Model queries for the latest N
 	// records (where N is equal to the height of the current viewport.Model)
 	// and pass the string to the viewport.Model for rendering
 	case plexer.Message:
-		color := pager.beams[msg.Label]
+		color := model.beams[msg.Label]
 
-		space := pager.maxLabelLength - len(msg.Label)
+		space := model.maxLabelLength - len(msg.Label)
 		if space < 0 {
 			space = 0
 		}
@@ -409,123 +211,37 @@ func (pager *Pager) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				msg.Label+strings.Repeat(" ", space),
 			) + " | "
 
-		pager.buffer.Append(append([]byte(prefix), msg.Data...))
+		model.buffer.Append(append([]byte(prefix), msg.Data...))
 
-		// while browsing through the logs do don't want to
-		// keep moving down the new logs
-		if pager.awaitInput && pager.relativeIndex >= 0 {
-			break
-		}
-
-		contents, _ := pager.peekBuffer(
-			pager.height,
-			ring.WithLineWrap(pager.width),
+		contents, _ := model.peekBuffer(
+			model.height,
+			ring.WithLineWrap(model.width),
 		)
-		pager.writer.Reset()
-		pager.view.SetContent(contents)
-		pager.view.GotoBottom()
+		model.writer.Reset()
+		model.view.SetContent(contents)
+		model.view.GotoBottom()
 	}
 
 	// propagate event to child models.
-	pager.view, cmd = pager.view.Update(msg)
+	model.view, cmd = model.view.Update(msg)
 	cmds = append(cmds, cmd)
 
-	pager.footer, cmd = pager.footer.Update(msg)
-	cmds = append(cmds, cmd)
-
-	// only there to avoid certain chars to be used as
-	// input for the input field.
-	// chars include: "j", "k"
-	if !pager.ignoreInput {
-		pager.input, cmd = pager.input.Update(msg)
-		cmds = append(cmds, cmd)
-	}
-	// ignoring input is only valid for one pass
-	// revert it before the next pass
-	pager.ignoreInput = false
-
-	return pager, tea.Batch(cmds...)
+	return model, tea.Batch(cmds...)
 }
 
-func (pager *Pager) View() string {
+func (model *Model) View() string {
 	return lipgloss.JoinVertical(lipgloss.Left,
-		pager.footer.View(),
-		pager.view.View(),
-		pager.input.View(),
+		model.view.View(),
 	)
-}
-
-// previousPage renders the current window shifted up by 1
-// and selects the relativeIndex of zero.
-func (pager *Pager) previousPage(opts ...func(int, []byte) []byte) {
-
-	if pager.offsetStart == 0 {
-		return
-	}
-
-	pager.relativeIndex = 0
-	pager.offsetStart--
-	if pager.offsetStart < 0 {
-		pager.offsetStart = 0
-	}
-
-	contents, pageSize := pager.offsetBuffer(
-		pager.offsetStart,
-		pager.height,
-		ring.WithInlineFormatting(pager.width, pager.absoluteIndex),
-		ring.WithLineWrap(pager.width),
-	)
-	pager.writer.Reset()
-	pager.pageSize = pageSize
-	pager.view.SetContent(contents)
-}
-
-// updatePage requests the same offset window from the buffer
-// however with a different line marked as selected
-func (pager *Pager) updatePage(selected int, opts ...func(int, []byte) []byte) {
-
-	contents, pageSize := pager.offsetBuffer(
-		pager.offsetStart,
-		pager.height,
-		ring.WithInlineFormatting(pager.width, selected),
-		ring.WithLineWrap(pager.width),
-	)
-	pager.writer.Reset()
-	pager.pageSize = pageSize
-
-	pager.view.SetContent(contents)
-}
-
-// nextPage "scrolls" the buffer down by one page defined bei the current viewport height.
-// The relativeIndex referring to the line in the current window selected is set to zero
-// again.
-func (pager *Pager) nextPage(opts ...func(int, []byte) []byte) {
-
-	pager.offsetStart += pager.relativeIndex
-	// reset relativeIndex since its relative to
-	// the current page. When the page changes
-	// the relative index is 0
-	pager.relativeIndex = 0
-
-	contents, pageSize := pager.offsetBuffer(
-		pager.offsetStart,
-		pager.height,
-		opts...,
-	)
-	pager.writer.Reset()
-
-	pager.pageSize = pageSize
-
-	pager.view.SetContent(contents)
 }
 
 // peekBuffer is a wrapper to read up to N of the last items form the buffer into
-// the pager.writer. peakBuffer does not reset the pager.writer.
-func (pager Pager) peekBuffer(n int, opts ...func(int, []byte) []byte) (string, int) {
+// the model.writer. peakBuffer does not reset the model.writer.
+func (model Model) peekBuffer(n int, opts ...func(int, []byte) []byte) (string, int) {
 
-	pageSize, err := pager.buffer.Peek(
-		&pager.writer,
-		pager.height,
+	pageSize, err := model.buffer.Peek(
+		&model.writer,
+		model.height,
 		opts...,
 	)
 	if err != nil {
@@ -533,42 +249,10 @@ func (pager Pager) peekBuffer(n int, opts ...func(int, []byte) []byte) (string, 
 		return "", pageSize
 	}
 
-	return pager.writer.String(), pageSize
+	return model.writer.String(), pageSize
 }
 
-func (pager Pager) offsetBuffer(start, end int, opts ...func(int, []byte) []byte) (string, int) {
-
-	pageSize, err := pager.buffer.Offset(
-		&pager.writer,
-		start,
-		end,
-		opts...,
-	)
-	if err != nil {
-		debug.Debug(err.Error())
-		return "", pageSize
-	}
-
-	return pager.writer.String(), pageSize
-}
-
-func (pager *Pager) setDimensions(width, height int) {
-	pager.width, pager.height = width-borderMargin, height-bottomSectionHeight-inputSectionHeight-magicNumber
-	pager.view.Width, pager.view.Height = pager.width, pager.height
-}
-
-func (pager *Pager) initFormattingMode(offset int) {
-	pager.offsetStart = offset
-	pager.absoluteIndex = pager.offsetStart
-	pager.relativeIndex = 0
-}
-
-func (pager *Pager) resetFormattingMode() {
-	pager.awaitInput = false
-	pager.offsetStart = -1
-	pager.relativeIndex = -1
-	pager.absoluteIndex = -1
-
-	pager.input.Reset()
-	pager.input.Blur()
+func (model *Model) setDimensions(width, height int) {
+	model.width, model.height = width-borderMargin, height-bottomSectionHeight-inputSectionHeight-magicNumber
+	model.view.Width, model.view.Height = model.width, model.height
 }

--- a/app/component/pager/pager.go
+++ b/app/component/pager/pager.go
@@ -14,18 +14,12 @@ import (
 )
 
 const (
-	bottomSectionHeight = 1
-	inputSectionHeight  = 1
-
 	borderMargin = 1
 
 	// wow literally no idea why this number hence
 	// the variable name - if you get why tell me and
 	// pls open a PR..else pls don't change it
 	magicNumber = 2
-
-	awaitInput = iota + 1
-	hasInput
 )
 
 var (
@@ -75,7 +69,7 @@ type Model struct {
 }
 
 func New(width, height int, buffer *ring.Buffer) *Model {
-	w, h := width-borderMargin, height-bottomSectionHeight-inputSectionHeight-magicNumber
+	w, h := width-borderMargin, height
 
 	view := viewport.New(w, h)
 	view.Height = h
@@ -184,6 +178,6 @@ func (model Model) peekBuffer(n int, opts ...func(int, []byte) []byte) (string, 
 }
 
 func (model *Model) setDimensions(width, height int) {
-	model.width, model.height = width-borderMargin, height-bottomSectionHeight-inputSectionHeight-magicNumber
+	model.width, model.height = width-borderMargin, height
 	model.view.Width, model.view.Height = model.width, model.height
 }

--- a/app/component/pager/pager.go
+++ b/app/component/pager/pager.go
@@ -120,7 +120,7 @@ func New(width, height int) *Pager {
 	debug.Print("[pager.New] width: %d (%d), height: %d (%d)\n", w, view.Width, h, view.Height)
 
 	input := textinput.New()
-	input.Placeholder = "line number (use k/j to move and ESC to exit)"
+	input.Placeholder = "line number (use k/j to move and ESC/q to exit)"
 	input.Prompt = ":"
 
 	return &Pager{
@@ -193,7 +193,7 @@ func (pager *Pager) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// exits the parsing mode. Has no effect
 		// while not in parsing mode (awaitInput == false)
-		case "esc":
+		case "esc", "q":
 			if !pager.awaitInput {
 				break
 			}

--- a/app/component/status/status.go
+++ b/app/component/status/status.go
@@ -1,4 +1,4 @@
-package pager
+package status
 
 import (
 	"fmt"
@@ -27,6 +27,11 @@ const (
 	labelDisconnected    = "SIGINT"
 	labelNewNotification = "(incoming)"
 )
+
+type Connection struct {
+	Label string
+	Color lipgloss.Color
+}
 
 type stream struct {
 	label        string
@@ -83,7 +88,7 @@ type Model struct {
 	isFormatMode bool
 }
 
-func newFooter(w, h int) *Model {
+func New(w, h int) *Model {
 	return &Model{
 		width: w,
 		err:   nil,
@@ -136,27 +141,27 @@ func (f *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// stays the same unless the same stream connects with a different label).
 	// Each stream has a random background color for readability the Model
 	// either uses a white or black foreground color
-	// case subscriber:
-	// 	fg := styles.InverseColor(msg.color)
-	// 	index, ok := f.streamIndex[msg.label]
-	// 	if !ok {
-	// 		f.streams = append(f.streams, stream{
-	// 			label:   msg.label,
-	// 			colorBg: msg.color,
-	// 			colorFg: fg,
-	// 			style: lipgloss.NewStyle().
-	// 				Background(msg.color).
-	// 				Foreground(fg).
-	// 				Padding(0, 1).
-	// 				Bold(true),
-	// 			count: 0,
-	// 		})
-	// 		// don't forget to update the index map
-	// 		f.streamIndex[msg.label] = len(f.streams) - 1
-	// 		break
-	// 	}
+	case Connection:
+		fg := styles.InverseColor(msg.Color)
+		index, ok := f.streamIndex[msg.Label]
+		if !ok {
+			f.streams = append(f.streams, stream{
+				label:   msg.Label,
+				colorBg: msg.Color,
+				colorFg: fg,
+				style: lipgloss.NewStyle().
+					Background(msg.Color).
+					Foreground(fg).
+					Padding(0, 1).
+					Bold(true),
+				count: 0,
+			})
+			// don't forget to update the index map
+			f.streamIndex[msg.Label] = len(f.streams) - 1
+			break
+		}
 
-	// 	f.streams[index].disconnected = false
+		f.streams[index].disconnected = false
 
 	case plexer.Unsubscribe:
 		index := f.streamIndex[string(msg)]

--- a/app/component/status/status.go
+++ b/app/component/status/status.go
@@ -1,0 +1,248 @@
+package pager
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/KonstantinGasser/scotty/app/styles"
+	plexer "github.com/KonstantinGasser/scotty/multiplexer"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	ModelStyle = lipgloss.NewStyle().
+			Padding(0, 1).
+			Border(lipgloss.DoubleBorder(), false, false, true, false)
+
+	newNotificationStyle = lipgloss.NewStyle().
+				MarginLeft(1).
+				Foreground(styles.DefaultColor.Border).
+				Render(labelNewNotification)
+
+	spacing = styles.Spacer(1).Render("")
+)
+
+const (
+	labelDisconnected    = "SIGINT"
+	labelNewNotification = "(incoming)"
+)
+
+type stream struct {
+	label        string
+	colorBg      lipgloss.Color
+	colorFg      lipgloss.Color
+	style        lipgloss.Style
+	count        int
+	disconnected bool
+
+	// works in conjunction with isFormatMode
+	// and is flipped when the parent mode
+	// propagates a multiplexer.Message msg to the model.
+	// Only if both isFormatMode and hasNewMessage are true
+	// an indication for the user about new (hidden) messages
+	// must be shown
+	hasNewMessages bool
+}
+
+type Model struct {
+	width, height int
+
+	// any error happing anywhere
+	// in the application should be shown
+	// in the Model.
+	// err represents the latest error
+	err error
+
+	// guards below fields
+	mtx sync.RWMutex
+	// number of logs stream by all streams
+	// dropping a stream results in logCount - len(stream)
+	logCount int
+	// slice of beams which are currently connected to scotty
+	connectedBeams map[string]*stream
+
+	// streamIndex holds the index of the stream
+	// to allow O(1) indexing of the streams slice.
+	// Problem we are trying to solve with this is the
+	// fact that maps don't guaranty same ordering when
+	// looping over the map. However, this leeds to the
+	// Model switching the stream info boxes which is annoying...
+	streamIndex map[string]int
+	// streams is the slice with the actual information about a stream.
+	// using the streamsIndex we can do a O(1) lookup for a specific stream
+	// but maintain ordering when looping over the list when calling View()
+	streams []stream
+
+	// isFormatMode is indicated by the Models parent model.
+	// It tells whether or not the user is currently browsing
+	// through the logs.
+	// If true and a new message is received by a stream we want
+	// to add an indicated next to the stream info telling that new
+	// logs are available
+	isFormatMode bool
+}
+
+func newFooter(w, h int) *Model {
+	return &Model{
+		width: w,
+		err:   nil,
+
+		mtx:            sync.RWMutex{},
+		logCount:       0,
+		connectedBeams: map[string]*stream{},
+
+		streamIndex:  make(map[string]int),
+		streams:      make([]stream, 0, 4), // 4 is a wage assumption of the number of potential streams connecting to scotty. Could be me could be less, but might help with not moving stuff around so much?
+		isFormatMode: false,
+	}
+}
+
+func (f *Model) Init() tea.Cmd {
+	return nil
+}
+
+func (f *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+
+	var (
+		cmds []tea.Cmd
+	)
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		f.width = msg.Width
+		// f.height = msg.Height -> not really interested in the tty height
+		return f, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			f.isFormatMode = true
+
+		// invoked by parent model when leaving
+		// formatting mode thus we want to reset
+		// values used to show hidden notifications
+		case "esc", "q":
+			f.isFormatMode = false
+			for i := range f.streams {
+				f.streams[i].hasNewMessages = false
+			}
+		}
+	// whenever a stream connects to scotty the event
+	// is propagated. The Model uses the event to
+	// display connected stream and the number of logs streamed.
+	// Streams which disconnect temporally are removed from the
+	// Model state (color coding is delegated from the pager and thus
+	// stays the same unless the same stream connects with a different label).
+	// Each stream has a random background color for readability the Model
+	// either uses a white or black foreground color
+	// case subscriber:
+	// 	fg := styles.InverseColor(msg.color)
+	// 	index, ok := f.streamIndex[msg.label]
+	// 	if !ok {
+	// 		f.streams = append(f.streams, stream{
+	// 			label:   msg.label,
+	// 			colorBg: msg.color,
+	// 			colorFg: fg,
+	// 			style: lipgloss.NewStyle().
+	// 				Background(msg.color).
+	// 				Foreground(fg).
+	// 				Padding(0, 1).
+	// 				Bold(true),
+	// 			count: 0,
+	// 		})
+	// 		// don't forget to update the index map
+	// 		f.streamIndex[msg.label] = len(f.streams) - 1
+	// 		break
+	// 	}
+
+	// 	f.streams[index].disconnected = false
+
+	case plexer.Unsubscribe:
+		index := f.streamIndex[string(msg)]
+		f.streams[index].disconnected = true
+
+	case plexer.Error:
+		// QUESTION @KonstantinGasser:
+		// How do I unset the error say after 15 seconds?
+		f.err = msg
+	case plexer.Message:
+		// lookup the stream which dispatched the event
+		// and increase the log count
+		index, ok := f.streamIndex[msg.Label]
+		if !ok {
+			break
+		}
+
+		f.streams[index].count++
+
+		if f.isFormatMode && !f.streams[index].hasNewMessages {
+			f.streams[index].hasNewMessages = true
+		}
+	}
+
+	return f, tea.Batch(cmds...)
+}
+
+func (f *Model) View() string {
+
+	var items = []string{}
+
+	if len(f.streams) <= 0 && f.err == nil {
+		txt := "beam the logs up, scotty is ready"
+		items = append(items,
+			styles.StatusBarLogCount(txt),
+		)
+	}
+
+	for i, stream := range f.streams {
+
+		var padding = spacing
+		if i >= len(f.streams)-1 {
+			padding = ""
+		}
+
+		// not space after last one thou
+		var info any = stream.count
+
+		if stream.disconnected {
+			items = append(items, stream.style.Render(
+				stream.label+":"+fmt.Sprint(labelDisconnected),
+			),
+				padding,
+			)
+			continue
+		}
+
+		if stream.hasNewMessages {
+			items = append(items, stream.style.Render(
+				stream.label+":"+fmt.Sprint(info)+newNotificationStyle,
+			),
+				padding,
+			)
+			continue
+		}
+
+		items = append(items, stream.style.Render(
+			stream.label+":"+fmt.Sprint(stream.count),
+		),
+			padding,
+		)
+	}
+
+	if f.err != nil {
+		items = append(items,
+			styles.Spacer(2).Render("	"), // add some space next to the beams
+			styles.ErrorInfo(f.err.Error()),
+		)
+	}
+
+	return ModelStyle.
+		Padding(0, 1).
+		Width(f.width - 1). // account for padding left/right
+		Render(
+			lipgloss.JoinHorizontal(lipgloss.Left,
+				items...,
+			),
+		)
+}

--- a/app/component/welcome/welcome.go
+++ b/app/component/welcome/welcome.go
@@ -75,7 +75,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.width = msg.Width - 2 // account for margin
+		m.width = msg.Width
 		m.height = msg.Height
 	}
 

--- a/beam/main.go
+++ b/beam/main.go
@@ -14,7 +14,7 @@ var version = "dev"
 
 func main() {
 
-	if len(os.Args) >= 1 && os.Args[1] == "version" {
+	if len(os.Args) >= 2 && os.Args[1] == "version" {
 		fmt.Printf("scotty:\t%s\n", version)
 		return
 	}

--- a/beam/main.go
+++ b/beam/main.go
@@ -10,7 +10,14 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+var version = "dev"
+
 func main() {
+
+	if len(os.Args) >= 1 && os.Args[1] == "version" {
+		fmt.Printf("scotty:\t%s\n", version)
+		return
+	}
 
 	protocol := flag.String("protocol", "unix", "logs can be stream/piped through unix sockets or tcp sockets")
 	addr := flag.String("addr", "/tmp/scotty.sock", "specify a custom unix socket to use or a tcp:ip addr")

--- a/main.go
+++ b/main.go
@@ -3,17 +3,28 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/KonstantinGasser/scotty/app"
 	"github.com/KonstantinGasser/scotty/multiplexer"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"net/http"
+	"net/http/pprof"
 )
+
+var version = "dev"
 
 func main() {
 
+	if len(os.Args) >= 1 && os.Args[1] == "version" {
+		fmt.Printf("scotty:\t%s\n", version)
+		return
+	}
+
 	network := flag.String("network", "unix", "network interface to listen for beams (option: tcp)")
 	addr := flag.String("addr", "/tmp/scotty.sock", "address for the network interface")
-	flag.Parse()
+	buffer := flag.Int("buffer", 4096, "buffer to store logs will hold up N items")
 
 	quite := make(chan struct{})
 
@@ -26,6 +37,7 @@ func main() {
 	go multiplex.Run()
 
 	ui, err := app.New(
+		*buffer,
 		quite,
 		multiplex.Errors(),
 		multiplex.Messages(),
@@ -40,6 +52,21 @@ func main() {
 	bubble := tea.NewProgram(ui,
 		tea.WithAltScreen(),
 	)
+
+	go func() {
+		mux := http.NewServeMux()
+
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		server := &http.Server{
+			Addr:    ":8081",
+			Handler: mux,
+		}
+		server.ListenAndServe()
+	}()
 
 	if _, err := bubble.Run(); err != nil {
 		fmt.Printf("unable to start scotty: %v", err)

--- a/main.go
+++ b/main.go
@@ -8,9 +8,6 @@ import (
 	"github.com/KonstantinGasser/scotty/app"
 	"github.com/KonstantinGasser/scotty/multiplexer"
 	tea "github.com/charmbracelet/bubbletea"
-
-	"net/http"
-	"net/http/pprof"
 )
 
 var version = "dev"
@@ -53,20 +50,20 @@ func main() {
 		tea.WithAltScreen(),
 	)
 
-	go func() {
-		mux := http.NewServeMux()
+	// go func() {
+	// 	mux := http.NewServeMux()
 
-		mux.HandleFunc("/debug/pprof/", pprof.Index)
-		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-		server := &http.Server{
-			Addr:    ":8081",
-			Handler: mux,
-		}
-		server.ListenAndServe()
-	}()
+	// 	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	// 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	// 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	// 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	// 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	// 	server := &http.Server{
+	// 		Addr:    ":8081",
+	// 		Handler: mux,
+	// 	}
+	// 	server.ListenAndServe()
+	// }()
 
 	if _, err := bubble.Run(); err != nil {
 		fmt.Printf("unable to start scotty: %v", err)

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var version = "dev"
 
 func main() {
 
-	if len(os.Args) >= 1 && os.Args[1] == "version" {
+	if len(os.Args) >= 2 && os.Args[1] == "version" {
 		fmt.Printf("scotty:\t%s\n", version)
 		return
 	}

--- a/ring/buffer.go
+++ b/ring/buffer.go
@@ -19,21 +19,14 @@ type Buffer struct {
 }
 
 // New initiates a new ring buffer with a set capacity.
-// The provided factor can be any number however one must
-// note that the capacity is the result of 1 << factor to
-// ensure an end capacity of the power of 2.
-// Example factors:
-// 	factor of 10 -> 1 << 10 == 1024
-// 	factor of 12 -> 1 << 12 == 4096
-// The resulting capacity is the number of slots available in
-// the ring buffer. To calculate the approximated memory size
+// To calculate the approximated memory size
 // one has to take the size of the on average expected []byte
-// stored in the buffer and compute: (1<<factor)*avg(item_size)
-func New(factor uint32) Buffer {
+// stored in the buffer and compute: capacity*avg(item_size)
+func New(size uint32) Buffer {
 	return Buffer{
-		capacity: 1 << factor,
+		capacity: size,
 		write:    0,
-		data:     make([][]byte, 1<<factor),
+		data:     make([][]byte, size),
 	}
 }
 

--- a/ring/buffer.go
+++ b/ring/buffer.go
@@ -38,9 +38,10 @@ func (buff Buffer) Nil(index int) bool {
 	return buff.data[index] == nil
 }
 
-func (buf *Buffer) Append(p []byte) {
+func (buf *Buffer) Write(p []byte) (int, error) {
 	buf.data[buf.write] = p
 	buf.write = (buf.write + 1) % buf.capacity
+	return len(p), nil
 }
 
 // Peek looks up up-to N of the last entries written in the buffer.

--- a/ring/buffer_test.go
+++ b/ring/buffer_test.go
@@ -33,7 +33,7 @@ func makeStringN(n int, fn func(i int) string) string {
 	return out
 }
 
-func TestAppend(t *testing.T) {
+func TestWrite(t *testing.T) {
 
 	var factor uint32 = 2
 
@@ -65,7 +65,7 @@ func TestAppend(t *testing.T) {
 		buf = New(factor)
 
 		for _, v := range tc.input {
-			buf.Append(v)
+			buf.Write(v)
 		}
 
 		for i := 0; i < len(tc.want); i++ {
@@ -133,7 +133,7 @@ func TestWindowN(t *testing.T) {
 		// prepare buffer for reading
 		buf = New(factor)
 		for _, v := range tc.input {
-			buf.Append(v)
+			buf.Write(v)
 		}
 
 		w = strings.Builder{}
@@ -148,7 +148,7 @@ func TestWindowN(t *testing.T) {
 	}
 }
 
-func BenchmarkAppend(b *testing.B) {
+func BenchmarkWrite(b *testing.B) {
 	b.ReportAllocs()
 
 	buf := New(12)
@@ -156,7 +156,7 @@ func BenchmarkAppend(b *testing.B) {
 	payload := []byte(`{"level":"warn","ts":1674335370.996341,"caller":"application/structred.go:34","msg":"caution this indicates X","index":188,"ts":1674335370.996334}`)
 
 	for i := 0; i < b.N; i++ {
-		buf.Append(payload)
+		buf.Write(payload)
 	}
 }
 
@@ -167,7 +167,7 @@ func BenchmarkWindowN(b *testing.B) {
 	payload := []byte(`{"level":"warn","ts":1674335370.996341,"caller":"application/structred.go:34","msg":"caution this indicates X","index":188,"ts":1674335370.996334}`)
 
 	for i := 0; i < (1<<12)+128; i++ {
-		buf.Append(payload)
+		buf.Write(payload)
 	}
 
 	b.ReportAllocs()
@@ -191,7 +191,7 @@ func BenchmarkWindowNWithPreGrow(b *testing.B) {
 	payload := []byte(`{"level":"warn","ts":1674335370.996341,"caller":"application/structred.go:34","msg":"caution this indicates X","index":188,"ts":1674335370.996334}`)
 
 	for i := 0; i < (1<<12)+128; i++ {
-		buf.Append(payload)
+		buf.Write(payload)
 	}
 
 	b.ReportAllocs()
@@ -222,7 +222,7 @@ func BenchmarkWindowNWithBytesBuffer(b *testing.B) {
 	payload := []byte(`{"level":"warn","ts":1674335370.996341,"caller":"application/structred.go:34","msg":"caution this indicates X","index":188,"ts":1674335370.996334}`)
 
 	for i := 0; i < (1<<12)+128; i++ {
-		buf.Append(payload)
+		buf.Write(payload)
 	}
 
 	b.ReportAllocs()
@@ -246,7 +246,7 @@ func BenchmarkWindowNWithBytesBufferGrow(b *testing.B) {
 	payload := []byte(`{"level":"warn","ts":1674335370.996341,"caller":"application/structred.go:34","msg":"caution this indicates X","index":188,"ts":1674335370.996334}`)
 
 	for i := 0; i < (1<<12)+128; i++ {
-		buf.Append(payload)
+		buf.Write(payload)
 	}
 
 	b.ReportAllocs()


### PR DESCRIPTION
While thinking about next features for scotty I noticed that the pager component was simply doing too much which was unrelated to paging the logs. The pager would also implement logic to format and brows the logs... As such I started separating the components and smarten up the App component.

Logic now:

App:
- decides what to show, propagates messages from the multiplexer to the current active view.
- listens for user input and invokes views accordingly 

Pager:
- only deals with reading latest N items from the buffer and displaying them

Formatter:
- only deals with formatting a log and allows to brows through the logs