### PR TITLE
Formatting issue 14

### DIFF
--- a/app/component/browsing/browsing.go
+++ b/app/component/browsing/browsing.go
@@ -93,8 +93,10 @@ func (model *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, model.bindings.Down):
 			model.formatter.Next()
+			model.prompt.SetValue(strconv.Itoa(int(model.formatter.Absolute())))
 		case key.Matches(msg, model.bindings.Up):
 			model.formatter.Privous()
+			model.prompt.SetValue(strconv.Itoa(int(model.formatter.Absolute())))
 		case key.Matches(msg, model.bindings.Exit):
 			model.prompt.Blur()
 			model.prompt.Reset()

--- a/app/component/browsing/browsing.go
+++ b/app/component/browsing/browsing.go
@@ -93,10 +93,10 @@ func (model *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, model.bindings.Down):
 			model.formatter.Next()
-			model.prompt.SetValue(strconv.Itoa(int(model.formatter.Absolute())))
+			model.prompt.SetValue(strconv.Itoa(int(model.formatter.CurrentIndex())))
 		case key.Matches(msg, model.bindings.Up):
 			model.formatter.Privous()
-			model.prompt.SetValue(strconv.Itoa(int(model.formatter.Absolute())))
+			model.prompt.SetValue(strconv.Itoa(int(model.formatter.CurrentIndex())))
 		case key.Matches(msg, model.bindings.Exit):
 			model.prompt.Blur()
 			model.prompt.Reset()

--- a/app/styles/layout.go
+++ b/app/styles/layout.go
@@ -1,7 +1,14 @@
 package styles
 
 import (
+	"bytes"
+	"strings"
+
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+	"github.com/muesli/ansi"
+	"github.com/muesli/reflow/truncate"
+	"github.com/muesli/termenv"
 )
 
 /* SCOTTY GRID LAYOUT AND STYLE */
@@ -53,9 +60,200 @@ func ActiveTab(label string) string {
 		Render(label)
 }
 
-func max(upper int, compare int) int {
-	if compare > upper {
-		return upper
+/*
+BEGIN OF COPYWRITE
+The following code is copied from a PR created on lipgloss
+to solve the issue of overlaying elements.
+Please see the PR:
+
+	https://github.com/buztard/lipgloss/tree/feature/overlay
+
+Could not find a Copywrite statement, however credits to @buztard (https://github.com/buztard)
+who implemented and created the PR. Once the PR or an alternative is released
+within the context of lipgloss this code will be replaced.
+
+Thanks @buztard, you saved my day/ui with this one :-)!
+*/
+func Overlay(
+	x, y int,
+	fg, bg string,
+	shadow bool,
+) string {
+	fgLines, fgWidth := getLines(fg)
+	bgLines, bgWidth := getLines(bg)
+	bgHeight := len(bgLines)
+	fgHeight := len(fgLines)
+
+	if shadow {
+		var shadowbg string = ""
+		shadowchar := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#333333")).
+			Render("░")
+		for i := 0; i <= fgHeight; i++ {
+			if i == 0 {
+				shadowbg += " " + strings.Repeat(" ", fgWidth) + "\n"
+			} else {
+				shadowbg += " " + strings.Repeat(shadowchar, fgWidth) + "\n"
+			}
+		}
+
+		fg = Overlay(0, 0, fg, shadowbg, false)
+		fgLines, fgWidth = getLines(fg)
+		fgHeight = len(fgLines)
 	}
-	return compare
+
+	if fgWidth >= bgWidth && fgHeight >= bgHeight {
+		// FIXME: return fg or bg?
+		return fg
+	}
+	// TODO: allow placement outside of the bg box?
+	x = clamp2(x, 0, bgWidth-fgWidth)
+	y = clamp2(y, 0, bgHeight-fgHeight)
+
+	ws := &whitespace{}
+
+	var b strings.Builder
+	for i, bgLine := range bgLines {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		if i < y || i >= y+fgHeight {
+			b.WriteString(bgLine)
+			continue
+		}
+
+		pos := 0
+		if x > 0 {
+			left := truncate.String(bgLine, uint(x))
+			pos = ansi.PrintableRuneWidth(left)
+			b.WriteString(left)
+			if pos < x {
+				b.WriteString(ws.render(x - pos))
+				pos = x
+			}
+		}
+
+		fgLine := fgLines[i-y]
+		b.WriteString(fgLine)
+		pos += ansi.PrintableRuneWidth(fgLine)
+
+		right := cutLeft(bgLine, pos)
+		bgWidth := ansi.PrintableRuneWidth(bgLine)
+		rightWidth := ansi.PrintableRuneWidth(right)
+		if rightWidth <= bgWidth-pos {
+			b.WriteString(ws.render(bgWidth - rightWidth - pos))
+		}
+
+		b.WriteString(right)
+	}
+
+	return b.String()
 }
+
+type whitespace struct {
+	style termenv.Style
+	chars string
+}
+
+func getLines(s string) (lines []string, widest int) {
+	lines = strings.Split(s, "\n")
+
+	for _, l := range lines {
+		w := ansi.PrintableRuneWidth(l)
+		if widest < w {
+			widest = w
+		}
+	}
+
+	return lines, widest
+}
+
+// cutLeft cuts printable characters from the left.
+// This function is heavily based on muesli's ansi and truncate packages.
+func cutLeft(s string, cutWidth int) string {
+	var (
+		pos    int
+		isAnsi bool
+		ab     bytes.Buffer
+		b      bytes.Buffer
+	)
+	for _, c := range s {
+		var w int
+		if c == ansi.Marker || isAnsi {
+			isAnsi = true
+			ab.WriteRune(c)
+			if ansi.IsTerminator(c) {
+				isAnsi = false
+				if bytes.HasSuffix(ab.Bytes(), []byte("[0m")) {
+					ab.Reset()
+				}
+			}
+		} else {
+			w = runewidth.RuneWidth(c)
+		}
+
+		if pos >= cutWidth {
+			if b.Len() == 0 {
+				if ab.Len() > 0 {
+					b.Write(ab.Bytes())
+				}
+				if pos-cutWidth > 1 {
+					b.WriteByte(' ')
+					continue
+				}
+			}
+			b.WriteRune(c)
+		}
+		pos += w
+	}
+	return b.String()
+}
+
+func clamp2(v, lower, upper int) int {
+	return min(max(v, lower), upper)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (w whitespace) render(width int) string {
+	if w.chars == "" {
+		w.chars = " "
+	}
+
+	r := []rune(w.chars)
+	j := 0
+	b := strings.Builder{}
+
+	// Cycle through runes and print them into the whitespace.
+	for i := 0; i < width; {
+		b.WriteRune(r[j])
+		j++
+		if j >= len(r) {
+			j = 0
+		}
+		i += ansi.PrintableRuneWidth(string(r[j]))
+	}
+
+	// Fill any extra gaps white spaces. This might be necessary if any runes
+	// are more than one cell wide, which could leave a one-rune gap.
+	short := width - ansi.PrintableRuneWidth(b.String())
+	if short > 0 {
+		b.WriteString(strings.Repeat(" ", short))
+	}
+
+	return w.style.Styled(b.String())
+}
+
+/* END OF COPYWRITE */

--- a/store/formatter.go
+++ b/store/formatter.go
@@ -49,8 +49,9 @@ type Formatter struct {
 	ttyWidth int
 }
 
-func (formatter Formatter) Absolute() uint32 { return formatter.absolute }
-func (formatter Formatter) Relative() uint8  { return formatter.relative }
+func (formtter Formatter) CurrentIndex() uint32 {
+	return formtter.buffer[formtter.relative].Index()
+}
 
 func (formatter *Formatter) Load(start int) {
 
@@ -67,7 +68,7 @@ func (formatter *Formatter) Next() {
 	formatter.absolute += 1
 
 	// turn page forward by formatter.size
-	if formatter.relative+1 > formatter.visibleItemCount-1 {
+	if formatter.relative+1 > formatter.size {
 		formatter.buffer = formatter.reader.Range(int(formatter.absolute), int(formatter.size))
 		formatter.relative = 0
 

--- a/store/formatter.go
+++ b/store/formatter.go
@@ -1,18 +1,14 @@
 package store
 
 import (
-	"bytes"
-	"fmt"
 	"strings"
 
+	"github.com/KonstantinGasser/scotty/app/styles"
 	"github.com/KonstantinGasser/scotty/store/ring"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/hokaccha/go-prettyjson"
-	"github.com/mattn/go-runewidth"
 	"github.com/muesli/ansi"
-	"github.com/muesli/reflow/truncate"
 	"github.com/muesli/reflow/wrap"
-	"github.com/muesli/termenv"
 )
 
 var (
@@ -37,13 +33,13 @@ type Formatter struct {
 	background string
 	foreground string
 
-	// selected refers to the ring.Item.index which
-	// is currently selected and should be formatted
-	selected uint32
-	// offset refers to the index offeset relativ to
+	// absolute refers to the ring.Item.index which
+	// is currently absolute and should be formatted
+	absolute uint32
+	// relative refers to the index offeset relativ to
 	// the current buffer/page and gives indications
 	// about page turns (froward and backend)
-	offset uint8
+	relative uint8
 	// visibleItemCount is the actual number of items
 	// which can currently be displayed under the current
 	// tty dimensions. It is given that visibleItemCount
@@ -53,48 +49,51 @@ type Formatter struct {
 	ttyWidth int
 }
 
+func (formatter Formatter) Absolute() uint32 { return formatter.absolute }
+func (formatter Formatter) Relative() uint8  { return formatter.relative }
+
 func (formatter *Formatter) Load(start int) {
 
-	formatter.buffer = formatter.reader.Range(start-1, int(formatter.size))
+	formatter.buffer = formatter.reader.Range(start, int(formatter.size))
 
-	formatter.offset = 0 // make the first item of the buffer be the selected item
-	formatter.selected = uint32(start - 1)
+	formatter.relative = 0 // make the first item of the buffer be the absolute item
+	formatter.absolute = uint32(start)
 
 	formatter.buildView()
 }
 
 func (formatter *Formatter) Next() {
 
-	formatter.selected += 1
+	formatter.absolute += 1
 
 	// turn page forward by formatter.size
-	if formatter.offset+1 > formatter.visibleItemCount-1 {
-		formatter.buffer = formatter.reader.Range(int(formatter.selected), int(formatter.size))
-		formatter.offset = 0
+	if formatter.relative+1 > formatter.visibleItemCount-1 {
+		formatter.buffer = formatter.reader.Range(int(formatter.absolute), int(formatter.size))
+		formatter.relative = 0
 
 		formatter.buildView()
 		return
 	}
 
-	formatter.offset += 1
+	formatter.relative += 1
 	formatter.buildView()
 }
 
 func (formatter *Formatter) Privous() {
 
-	if formatter.selected-1 == 0 {
+	if formatter.absolute-1 == 0 {
 		return
 	}
 
-	formatter.selected -= 1
-	if formatter.offset == 0 {
-		formatter.buffer = formatter.reader.Range(int(formatter.selected), int(formatter.size))
+	formatter.absolute -= 1
+	if formatter.relative == 0 {
+		formatter.buffer = formatter.reader.Range(int(formatter.absolute), int(formatter.size))
 
 		formatter.buildView()
 		return
 	}
 
-	formatter.offset -= 1
+	formatter.relative -= 1
 	formatter.buildView()
 }
 
@@ -104,47 +103,36 @@ func (formatter *Formatter) buildView() {
 	formatter.buildForeground()
 }
 
+var selected = ">>>"
+var trimmedSuffix = "..."
+
 func (formatter *Formatter) buildBackground() {
 
-	var height, lines, tmp = 0, []string{}, make([]string, formatter.size)
-	var written uint8
+	var lines = make([]string, formatter.size)
 
-	formatter.visibleItemCount = 0
-
+	var printable, ansiEsc int
 	for i, item := range formatter.buffer {
 
-		if written >= formatter.size {
-			break
+		var raw = strings.Builder{}
+
+		if i == int(formatter.relative) {
+			raw.WriteString(selected)
 		}
+		raw.WriteString(item.Raw)
 
-		formatter.visibleItemCount += 1
+		printable = ansi.PrintableRuneWidth(raw.String())
+		ansiEsc = len(raw.String()) - printable
 
-		lines = nil
-		if len(item.Raw) <= 0 {
+		if printable > formatter.ttyWidth {
+			tmp := raw.String()[:formatter.ttyWidth+(ansiEsc-1)]
+			lines[i] = tmp[:len(tmp)-1-len(trimmedSuffix)] + trimmedSuffix
 			continue
 		}
 
-		var prefixOptions []func(string) string
-		if i == int(formatter.offset) {
-			prefixOptions = append(prefixOptions, func(s string) string {
-				return fmt.Sprintf("%s%s", lipgloss.NewStyle().Bold(true).Render(">>"), s)
-			})
-		}
-
-		height, lines = buildLines(item, formatter.ttyWidth, prefixOptions...)
-
-		if int(written)+height <= int(formatter.size) {
-			for _, line := range lines {
-				tmp[written] = line
-				written += 1
-			}
-			continue
-		}
-
-		tmp = append(tmp[height:], lines...)
+		lines[i] = raw.String()
+		raw.Reset()
 	}
-
-	formatter.background = strings.Join(tmp, "\n")
+	formatter.background = strings.Join(lines, "\n")
 }
 
 var (
@@ -166,7 +154,7 @@ func modalWidth(full int) int {
 
 func (formatter *Formatter) buildForeground() {
 
-	item := formatter.reader.At(uint32(formatter.selected))
+	item := formatter.reader.At(uint32(formatter.absolute))
 
 	pretty, _ := jsonF.Format(
 		[]byte(item.Raw[item.DataPointer:]),
@@ -187,7 +175,7 @@ func (formatter *Formatter) buildForeground() {
 func (formatter *Formatter) Reset(width int, height uint8) {
 	formatter.ttyWidth = width
 	formatter.size = height
-	formatter.selected = 0
+	formatter.absolute = 0
 	formatter.buffer = make([]ring.Item, formatter.size)
 }
 
@@ -197,203 +185,5 @@ func (formatter Formatter) String() string {
 	x0 := int(formatter.ttyWidth/2) - int(modalWidth/2)
 	y0 := int(formatter.size/2) - int(modalHeight/2)
 
-	return PlaceOverlay(x0, y0, formatter.foreground, formatter.background, false)
+	return styles.Overlay(x0, y0, formatter.foreground, formatter.background, false)
 }
-
-/*
-BEGIN OF COPYWRITE
-The following code is copied from a PR created on lipgloss
-to solve the issue of overlaying elements.
-Please see the PR:
-
-	https://github.com/buztard/lipgloss/tree/feature/overlay
-
-Could not find a Copywrite statement, however credits to @buztard (https://github.com/buztard)
-who implemented and created the PR. Once the PR or an alternative is released
-within the context of lipgloss this code will be replaced.
-
-Thanks @buztard, you saved my day/ui with this one :-)!
-*/
-func PlaceOverlay(
-	x, y int,
-	fg, bg string,
-	shadow bool,
-) string {
-	fgLines, fgWidth := getLines(fg)
-	bgLines, bgWidth := getLines(bg)
-	bgHeight := len(bgLines)
-	fgHeight := len(fgLines)
-
-	if shadow {
-		var shadowbg string = ""
-		shadowchar := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#333333")).
-			Render("░")
-		for i := 0; i <= fgHeight; i++ {
-			if i == 0 {
-				shadowbg += " " + strings.Repeat(" ", fgWidth) + "\n"
-			} else {
-				shadowbg += " " + strings.Repeat(shadowchar, fgWidth) + "\n"
-			}
-		}
-
-		fg = PlaceOverlay(0, 0, fg, shadowbg, false)
-		fgLines, fgWidth = getLines(fg)
-		fgHeight = len(fgLines)
-	}
-
-	if fgWidth >= bgWidth && fgHeight >= bgHeight {
-		// FIXME: return fg or bg?
-		return fg
-	}
-	// TODO: allow placement outside of the bg box?
-	x = clamp2(x, 0, bgWidth-fgWidth)
-	y = clamp2(y, 0, bgHeight-fgHeight)
-
-	ws := &whitespace{}
-
-	var b strings.Builder
-	for i, bgLine := range bgLines {
-		if i > 0 {
-			b.WriteByte('\n')
-		}
-		if i < y || i >= y+fgHeight {
-			b.WriteString(bgLine)
-			continue
-		}
-
-		pos := 0
-		if x > 0 {
-			left := truncate.String(bgLine, uint(x))
-			pos = ansi.PrintableRuneWidth(left)
-			b.WriteString(left)
-			if pos < x {
-				b.WriteString(ws.render(x - pos))
-				pos = x
-			}
-		}
-
-		fgLine := fgLines[i-y]
-		b.WriteString(fgLine)
-		pos += ansi.PrintableRuneWidth(fgLine)
-
-		right := cutLeft(bgLine, pos)
-		bgWidth := ansi.PrintableRuneWidth(bgLine)
-		rightWidth := ansi.PrintableRuneWidth(right)
-		if rightWidth <= bgWidth-pos {
-			b.WriteString(ws.render(bgWidth - rightWidth - pos))
-		}
-
-		b.WriteString(right)
-	}
-
-	return b.String()
-}
-
-type whitespace struct {
-	style termenv.Style
-	chars string
-}
-
-func getLines(s string) (lines []string, widest int) {
-	lines = strings.Split(s, "\n")
-
-	for _, l := range lines {
-		w := ansi.PrintableRuneWidth(l)
-		if widest < w {
-			widest = w
-		}
-	}
-
-	return lines, widest
-}
-
-// cutLeft cuts printable characters from the left.
-// This function is heavily based on muesli's ansi and truncate packages.
-func cutLeft(s string, cutWidth int) string {
-	var (
-		pos    int
-		isAnsi bool
-		ab     bytes.Buffer
-		b      bytes.Buffer
-	)
-	for _, c := range s {
-		var w int
-		if c == ansi.Marker || isAnsi {
-			isAnsi = true
-			ab.WriteRune(c)
-			if ansi.IsTerminator(c) {
-				isAnsi = false
-				if bytes.HasSuffix(ab.Bytes(), []byte("[0m")) {
-					ab.Reset()
-				}
-			}
-		} else {
-			w = runewidth.RuneWidth(c)
-		}
-
-		if pos >= cutWidth {
-			if b.Len() == 0 {
-				if ab.Len() > 0 {
-					b.Write(ab.Bytes())
-				}
-				if pos-cutWidth > 1 {
-					b.WriteByte(' ')
-					continue
-				}
-			}
-			b.WriteRune(c)
-		}
-		pos += w
-	}
-	return b.String()
-}
-
-func clamp2(v, lower, upper int) int {
-	return min(max(v, lower), upper)
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func (w whitespace) render(width int) string {
-	if w.chars == "" {
-		w.chars = " "
-	}
-
-	r := []rune(w.chars)
-	j := 0
-	b := strings.Builder{}
-
-	// Cycle through runes and print them into the whitespace.
-	for i := 0; i < width; {
-		b.WriteRune(r[j])
-		j++
-		if j >= len(r) {
-			j = 0
-		}
-		i += ansi.PrintableRuneWidth(string(r[j]))
-	}
-
-	// Fill any extra gaps white spaces. This might be necessary if any runes
-	// are more than one cell wide, which could leave a one-rune gap.
-	short := width - ansi.PrintableRuneWidth(b.String())
-	if short > 0 {
-		b.WriteString(strings.Repeat(" ", short))
-	}
-
-	return w.style.Styled(b.String())
-}
-
-/* END OF COPYWRITE */

--- a/store/formatter_test.go
+++ b/store/formatter_test.go
@@ -17,7 +17,7 @@ func TestBuildView(t *testing.T) {
 	formatter := store.NewFormatter(uint8(pageSize), ttyWidth)
 
 	testLabel := "test"
-	testLog := `{"hello": "world", "index": {index}}`
+	testLog := `{"hello": "world", "level": "debug", "index": {index}}`
 	for i := 0; i < fill; i++ {
 		log := strings.Replace(testLog, "{index}", fmt.Sprint(i), 1)
 		raw := testLabel + " | " + log
@@ -28,6 +28,23 @@ func TestBuildView(t *testing.T) {
 	formatter.Load(1)
 
 	formatted := formatter.String()
+
+	want := []string{
+		`>>>t╭────────────────────────────────────────╮..`,
+		`test│ test |                                 │..`,
+		`test│ {                                      │..`,
+		`test│   "hello": "world",                    │..`,
+		`test│   "index": 1,                          │..`,
+		`test│   "level": "debug"                     │..`,
+		`test│ }                                      │..`,
+		`test╰────────────────────────────────────────╯..`,
+	}
+
+	for i, line := range strings.Split(formatted, "\n") {
+		if want[i] != line {
+			t.Fatalf("wanted line: %q - got: %q", want[i], line)
+		}
+	}
 
 	t.Logf(`[formatter.buildView]
 DUE TO ANSI COLORS TESTING IS HARD.

--- a/store/pager_test.go
+++ b/store/pager_test.go
@@ -17,9 +17,9 @@ func TestMoveDownNoOverflow(t *testing.T) {
 	}
 
 	sequence := []string{
-		"[1] test-label | Line-1\n\n\n",
-		"[1] test-label | Line-1\n[2] test-label | Line-2\n\n",
-		"[1] test-label | Line-1\n[2] test-label | Line-2\n[3] test-label | Line-3\n",
+		"[1] test-label | Line-1\n\x00\n\x00\n\x00",
+		"[1] test-label | Line-1\n[2] test-label | Line-2\n\x00\n\x00",
+		"[1] test-label | Line-1\n[2] test-label | Line-2\n[3] test-label | Line-3\n\x00",
 		"[1] test-label | Line-1\n[2] test-label | Line-2\n[3] test-label | Line-3\n[4] test-label | Line-4",
 	}
 
@@ -43,9 +43,9 @@ func TestMoveDownOverflow(t *testing.T) {
 	}
 
 	sequence := []string{
-		"[1] test-label | Line-1\n\n\n",
-		"[1] test-label | Line-1\n[2] test-label | Line-2\n\n",
-		"[1] test-label | Line-1\n[2] test-label | Line-2\n[3] test-label | Line-3\n",
+		"[1] test-label | Line-1\n\x00\n\x00\n\x00",
+		"[1] test-label | Line-1\n[2] test-label | Line-2\n\x00\n\x00",
+		"[1] test-label | Line-1\n[2] test-label | Line-2\n[3] test-label | Line-3\n\x00",
 		"[1] test-label | Line-1\n[2] test-label | Line-2\n[3] test-label | Line-3\n[4] test-label | Line-4",
 		"[2] test-label | Line-2\n[3] test-label | Line-3\n[4] test-label | Line-4\n[5] test-label | Line-5",
 		"[3] test-label | Line-3\n[4] test-label | Line-4\n[5] test-label | Line-5\n[6] test-label | Line-6",

--- a/store/ring/buffer.go
+++ b/store/ring/buffer.go
@@ -1,5 +1,7 @@
 package ring
 
+import "github.com/KonstantinGasser/scotty/debug"
+
 type Reader interface {
 	At(i uint32) Item
 	Range(start int, size int) Slice
@@ -109,7 +111,7 @@ func (buf *Buffer) Range(start int, size int) Slice {
 
 	for i := start; i < start+size; i++ {
 		index = buf.marshalIndex(uint32(i))
-
+		debug.Print("Index: %d\n", index)
 		out = append(out, buf.data[index])
 	}
 

--- a/store/ring/buffer_test.go
+++ b/store/ring/buffer_test.go
@@ -52,6 +52,16 @@ func TestRangeNoOverflow(t *testing.T) {
 				{Raw: "Line-9"},
 			},
 		},
+		{
+			name:  "random range",
+			start: 5,
+			size:  8,
+			want: []Item{
+				{Raw: "Line-4"},
+				{Raw: "Line-5"},
+				{Raw: "Line-6"},
+			},
+		},
 	}
 
 	for _, tc := range tt {

--- a/store/store.go
+++ b/store/store.go
@@ -45,6 +45,7 @@ func (store Store) NewFormatter(size uint8, width int) Formatter {
 		size:     size,
 		ttyWidth: width,
 		reader:   &store.buffer,
-		selected: 0,
+		absolute: 0,
+		relative: 0,
 	}
 }

--- a/test/application/structred.go
+++ b/test/application/structred.go
@@ -37,7 +37,7 @@ func main() {
 
 	sl.Info("Hello Scotty", zap.String("state", "ready to beam"), zap.Int("index", 0))
 
-	var i int = 1
+	var i int = 0
 	for {
 		i++
 		time.Sleep(time.Millisecond * time.Duration(*delay))


### PR DESCRIPTION
closes #14 

fixed:
- while formatting log lines which are too long are cut of since a preview is offered
- panic fixed when scrolling the next page while formatting

added:
- update of input value for log index to reflect current selected item id