### PR TITLE
Pager mem leak

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,10 +48,28 @@ snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+    - Merge remote-tracking branch
+    - Merge branch
+  groups:
+    - layout: post
+title: 'Features'
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - layout: post
+title: 'Fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 10
+    - layout: post
+title: Other work
+      order: 999
+  # sort: asc
+  # filters:
+  #   exclude:
+  #     - '^docs:'
+  #     - '^test:'
 
 brews:
   - name: scotty

--- a/app/bindings/bindings_test.go
+++ b/app/bindings/bindings_test.go
@@ -3,33 +3,12 @@ package bindings
 import (
 	"testing"
 
-	// "github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
-	// "github.com/kr/pretty"
 )
-
-// func TestSimpleSeqTree(t *testing.T) {
-//
-// 	m := NewMap()
-//
-// 	m.Bind("f").Action(func(km tea.KeyMsg) tea.Cmd {
-// 		return func() tea.Msg {
-// 			return "hello world"
-// 		}
-// 	})
-//
-// 	pretty.Print(m.binds["f"])
-// }
 
 func TestOptionSeqTree(t *testing.T) {
 
 	m := NewMap()
-
-	// m.Bind(" ").Option("f").Action(func(km tea.KeyMsg) tea.Cmd {
-	// 	return func() tea.Msg {
-	// 		return "called: SPC->f"
-	// 	}
-	// })
 
 	m.Bind(" ").Option("f").Action(func(km tea.KeyMsg) tea.Cmd {
 		return func() tea.Msg {

--- a/app/component/browsing/browsing.go
+++ b/app/component/browsing/browsing.go
@@ -142,9 +142,13 @@ func (model *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		model.prompt.Width = promptWidth
 
 		if !model.ready {
-			model.formatter.Reset(model.width, uint8(model.height))
 			model.ready = true
+			model.formatter.Reset(model.width, uint8(model.height))
+			break
 		}
+
+		model.formatter.Resize(model.width, uint8(model.height))
+
 	case tea.KeyMsg:
 		if model.bindings.Matches(msg) {
 			cmds = append(cmds, model.bindings.Exec(msg).Call(msg))

--- a/app/component/browsing/browsing.go
+++ b/app/component/browsing/browsing.go
@@ -87,6 +87,7 @@ func New(formatter store.Formatter) *Model {
 				if model.prompt.Focused() {
 					return nil
 				}
+				model.prompt.Reset()
 				model.prompt.Prompt = focusedPromptChar
 				return tea.Batch(model.prompt.Focus(), info.RequestMode(info.ModePromptActive))
 			},

--- a/app/component/tailing/tailing.go
+++ b/app/component/tailing/tailing.go
@@ -3,6 +3,7 @@ package tailing
 import (
 	"github.com/KonstantinGasser/scotty/app/bindings"
 	"github.com/KonstantinGasser/scotty/app/styles"
+	"github.com/KonstantinGasser/scotty/debug"
 	"github.com/KonstantinGasser/scotty/store"
 	"github.com/KonstantinGasser/scotty/stream"
 	tea "github.com/charmbracelet/bubbletea"
@@ -35,11 +36,13 @@ func New(pager store.Pager) *Model {
 	model.bindings.Bind("p").Action(func(msg tea.KeyMsg) tea.Cmd {
 		if model.state == paused {
 			model.state = running
+			model.pager.ResumeRender()
 			model.pager.Refresh()
 			return RequestResume()
 		}
 
 		model.state = paused
+		model.pager.PauseRender()
 		return RequestPause()
 	})
 
@@ -79,7 +82,7 @@ func (model *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		cmds = append(cmds, model.bindings.Exec(msg).Call(msg))
 	case stream.Message:
-		model.pager.MoveDown(model.state == paused)
+		model.pager.MovePosition()
 	}
 
 	return model, tea.Batch(cmds...)

--- a/app/component/welcome/welcome.go
+++ b/app/component/welcome/welcome.go
@@ -114,14 +114,6 @@ func (m *Model) View() string {
 		styles.SpaceBetween(betweenSmall, browseKeyActions, browseKeyBindings, "."),
 	)
 
-	// usageStderr := lipgloss.JoinVertical(lipgloss.Center,
-	// 	lipgloss.PlaceHorizontal(betweenMedium, lipgloss.Center, lipgloss.NewStyle().Render("Usage")),
-	// 	styles.SpaceBetween(betweenMedium, useageFormats[0:1], []string{".", "."}, "."),
-	// )
-	// usageStdout := lipgloss.JoinVertical(lipgloss.Center,
-	// 	lipgloss.PlaceHorizontal(betweenMedium, lipgloss.Center, lipgloss.NewStyle().Render("Usage")),
-	// 	styles.SpaceBetween(betweenMedium, useageFormats[1:], []string{".", "."}, "."),
-	// )
 	usageStderr := styles.SpaceBetween(betweenMedium, useageFormats[0:1], []string{".", "."}, ".")
 	usageStdout := styles.SpaceBetween(betweenMedium, useageFormats[1:], []string{".", "."}, ".")
 

--- a/store/formatter.go
+++ b/store/formatter.go
@@ -208,6 +208,13 @@ func (formatter *Formatter) Reset(width int, height uint8) {
 	formatter.buffer = make([]ring.Item, formatter.size)
 }
 
+func (formatter *Formatter) Resize(width int, height uint8) {
+	formatter.ttyWidth = width
+	formatter.size = height
+
+	formatter.buildView()
+}
+
 func (formatter Formatter) String() string {
 
 	modalWidth, modalHeight := lipgloss.Width(formatter.foreground), lipgloss.Height(formatter.foreground)

--- a/store/formatter_test.go
+++ b/store/formatter_test.go
@@ -30,14 +30,14 @@ func TestBuildView(t *testing.T) {
 	formatted := formatter.String()
 
 	want := []string{
-		`>>>t╭────────────────────────────────────────╮..`,
-		`test│ test |                                 │..`,
-		`test│ {                                      │..`,
-		`test│   "hello": "world",                    │..`,
-		`test│   "index": 1,                          │..`,
-		`test│   "level": "debug"                     │..`,
-		`test│ }                                      │..`,
-		`test╰────────────────────────────────────────╯..`,
+		`[1]>╭────────────────────────────────────────╮..`,
+		`[2]t│ test |                                 │..`,
+		`[3]t│ {                                      │..`,
+		`[4]t│   "hello": "world",                    │..`,
+		`[5]t│   "index": 1,                          │..`,
+		`[6]t│   "level": "debug"                     │..`,
+		`[7]t│ }                                      │..`,
+		`[8]t╰────────────────────────────────────────╯..`,
 	}
 
 	for i, line := range strings.Split(formatted, "\n") {

--- a/store/pager.go
+++ b/store/pager.go
@@ -9,6 +9,9 @@ import (
 )
 
 type Pager struct {
+	// if enabled the bufferView is
+	// not updated for each received message
+	paused bool
 	// reader includes all required APIs
 	// to perform read operations on the ringbuffer
 	reader ring.Reader
@@ -41,8 +44,25 @@ type Pager struct {
 	// is full since until then we only need to append data not
 	// trim at the beginning
 	written uint8
-
+	// ticker is used to only build the buffered view if the
+	// configured refresh time has been reached in order
+	// to allow to minimize the cost of re-building
 	ticker *time.Ticker
+	// scrollDelta is used to determine the delta position
+	// when starting to scroll up or down. Scrolling is only
+	// possible if the tailing mode is paused (we can debate
+	// if it makes sense to pause tailing the moment a ScrollMsg
+	// is emitted).
+	// A negative delta means based on the starting position
+	// content above/previous from that position is requested.
+	// A delta of 0 implies that the scrolled view matches the
+	// initital view when the tailing has been paused
+	scrollDelta int32
+	// scrollBuffer holds the current items which are
+	// determined by the scrollDelta. This buffer is
+	// only filled and maintained while scrolling is
+	// executed afterwards its drained.
+	scrollBuffer []ring.Item
 }
 
 // MoveDown shifts the pagers content down by one item
@@ -56,13 +76,25 @@ type Pager struct {
 // The pager.bufferView is updated with the shifted content.
 // MoveDown will ensure that the number of \n (lines) in the
 // pager.bufferView is not exceeding the current pager.size.
-func (pager *Pager) MoveDown(skipRefresh bool) {
+//
+// Major issue as of now:
+// The capacity of the buffer is increasing to most twice
+// the starting capacity of the buffer and then slowly shrinks
+// back to the starting capacity which should increase the
+// memmove and growSlice runtime calls which have a certain
+// performance penalty.
+// This issue will not be fixed in this function but rather a
+// new improved function is written.
+func (pager *Pager) MoveDownDeprecated(skipRefresh bool) {
+	// defer debug.Print("Len: %d - Cap: %d\n", len(pager.buffer), cap(pager.buffer))
+
 	next := pager.reader.At(pager.position)
 	pager.position++
 	// lines holds a single log line wrapped
 	// into multiple strings each no longer than
 	// pager.ttyWidth
 	_, lines := buildLines(next, pager.ttyWidth)
+	// debug.Print("Len: %d - Cap: %d - NewLines: %d\n", len(pager.buffer), cap(pager.buffer), len(lines))
 
 	// insert new log line into buffer
 	for _, line := range lines {
@@ -99,10 +131,79 @@ func (pager *Pager) MoveDown(skipRefresh bool) {
 	}
 }
 
+// MovePosition moves the buffers viewing position
+// by one.
+// This means that any new value in the backing ring.Buffer
+// is cached in the pager's buffer after being processed (broken
+// into multiple lines if nessecarry).
+// The buffer's view is not changed and must be called indendenly
+func (pager *Pager) MovePosition() {
+
+	next := pager.reader.At(pager.position)
+	pager.position += 1
+
+	_, lines := buildLines(next, pager.ttyWidth)
+
+	// if less than zero -> pager can write all lines in the not yet full
+	// buffer.
+	// Results > 0 imply that only so many lines can be written in the not full
+	// buffer before the starting items must be truncated
+	overflow := (int(pager.written) + len(lines)) - cap(pager.buffer)
+
+	if overflow <= 0 {
+		for _, line := range lines {
+			pager.buffer[pager.written] = line
+			pager.written += 1
+		}
+
+		// we are done all possible lines where written
+		// in the buffer
+		return
+	}
+
+	// ok at this point we know that either not all lines fitted
+	// in the not yet full buffer and some are left-over or that the
+	// buffer was full to begin with an all lines must be append and
+	// the first lines in the buffer must be truncated.
+	// Either way it's the same...
+
+	// shift the buffer to the left by how many lines need to be written
+	// essentially truncating N lines from the beginning of the buffer.
+	// Question:
+	// why not using sliceing [N:], see func MoveDownDeprecated and
+	// the not regarding growSlice and memmove.
+	for i := overflow; i < cap(pager.buffer); i++ {
+		pager.buffer[i-overflow] = pager.buffer[i]
+	}
+
+	// append new lines without increasing the slice capacity
+	for i, j := (cap(pager.buffer)-1)-(overflow-1), 0; i < cap(pager.buffer); i, j = i+1, j+1 {
+		pager.buffer[i] = lines[j]
+	}
+}
+
+func (pager *Pager) PauseRender()  { pager.paused = true }
+func (pager *Pager) ResumeRender() { pager.paused = false }
+
 // String returns a finshed formatted string representing
 // the current state of the pager.
 func (pager *Pager) String() string {
-	return pager.bufferView
+	if pager.paused {
+		return pager.bufferView
+	}
+
+	if pager.ticker == nil {
+		pager.bufferView = strings.Join(pager.buffer, "\n")
+		return pager.bufferView
+	}
+
+	select {
+	case <-pager.ticker.C:
+		pager.bufferView = strings.Join(pager.buffer, "\n")
+		return pager.bufferView
+	default:
+		return pager.bufferView
+	}
 }
 
 // Rerender updates the pagers internal view which depends on

--- a/store/pager_test.go
+++ b/store/pager_test.go
@@ -30,7 +30,7 @@ func TestMoveDownNoOverflow(t *testing.T) {
 
 	// seqID := 0
 	for _, seq := range sequence {
-		pager.MoveDown(false)
+		pager.MoveDownDeprecated(false)
 		if seq != pager.String() {
 			t.Fatalf("[pager.MoveDown] expected line(s):\n%q\ngot:\n%q", seq, pager.String())
 		}
@@ -60,7 +60,7 @@ func TestMoveDownOverflow(t *testing.T) {
 	}
 
 	for _, seq := range sequence {
-		pager.MoveDown(false)
+		pager.MoveDownDeprecated(false)
 		if seq != pager.String() {
 			t.Fatalf("[pager.MoveDown] expected line(s):\n%q\ngot:\n%q", seq, pager.String())
 		}
@@ -179,7 +179,7 @@ func TestMoveDownAssertHeight(t *testing.T) {
 
 		for _, seq := range tc.sequence {
 			store.Insert("test-label", len(prefix), []byte(seq))
-			pager.MoveDown(false)
+			pager.MoveDownDeprecated(false)
 		}
 
 		contents := pager.String()
@@ -201,7 +201,7 @@ func TestMoveDownAssertHeight(t *testing.T) {
 
 func BenchmarkMoveDown(b *testing.B) {
 	store := New(2048)
-	pager := store.NewPager(44, 100, testRefreshRate)
+	pager := store.NewPager(44, 75, testRefreshRate)
 
 	// fill ring buffer until full so pager.position always is a hit
 	for i := 0; i < 2048; i++ {
@@ -212,6 +212,23 @@ func BenchmarkMoveDown(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		pager.MoveDown(false)
+		pager.MoveDownDeprecated(false)
+	}
+}
+
+func BenchmarkMovePosition(b *testing.B) {
+	store := New(2048)
+	pager := store.NewPager(44, 75, testRefreshRate)
+
+	// fill ring buffer until full so pager.position always is a hit
+	for i := 0; i < 2048; i++ {
+		store.Insert("dummy", 0, []byte(`{"level":"warn","ts":1680212791.946584,"caller":"application/structred.go:39","msg":"caution this indicates X","index":998,"ts":1680212791.946579}`))
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		pager.MovePosition()
 	}
 }

--- a/store/ring/buffer.go
+++ b/store/ring/buffer.go
@@ -61,7 +61,7 @@ func New(size uint32) *Buffer {
 		capacity: size,
 		head:     0,
 		written:  0,
-		data:     make([]Item, size),
+		data:     make([]Item, size, size),
 	}
 }
 

--- a/store/ring/buffer.go
+++ b/store/ring/buffer.go
@@ -130,7 +130,7 @@ func (buf *Buffer) HasData(index uint32) bool {
 		return false
 	}
 
-	return len(buf.data[index].Raw) > 0
+	return len(buf.data[buf.marshalIndex(index)].Raw) > 0
 }
 
 func (buf *Buffer) marshalIndex(absolute uint32) uint32 {

--- a/store/ring/buffer_test.go
+++ b/store/ring/buffer_test.go
@@ -199,7 +199,7 @@ func newFilledBuffer(size int, writes int, fn func(i int) string) *Buffer {
 			Raw: fn(i),
 		})
 	}
-	return &buf
+	return buf
 }
 
 func TestOffsetWrite(t *testing.T) {


### PR DESCRIPTION
in the previous function in the `store/pager` the func `MoveDown` would fill the pager's buffer up initially and once full truncate lines from the beginning in order to append the new lines at the end of the buffer. Lastly, `MoveDow` would recompute the `bufferView` if certain conditions where meet.

However, this function ignored that each time we do `buffer = buffer[n:]` we create a new slice still with the same backing array just a different window but with a changed capacity for the new slice. Than when appending the new lines with `append(buffer, lines...)` the capacity would not be enough and doubled in size. All this lead to a moving capacity..

The new function `MovePosition` shifts all items in the buffer to the left by N where N is the number of new lines which will be added to the buffer. As a result the capacity does not move and stays the same. 

Even-though not noticeable in the benchmarks my assumption was that due to the static capacity runtime calls to `growSlice` and `memMove` would be reduced. Not completely sure why it's not reflecting in the benchmarks which where about the same (`MovePosition` took about 20ns longer but had about 200 fewer B/op).


Lastly, included in this Pull-Request is the change that `MovePosition` no longer builds the `bufferView` if the refresh-rate allows it to and the pager is not in the state `paused`. This functionality has been moved to the `pager.String` function.

current benchmarks for the new `MovePosition` func are:

```
BenchmarkMovePosition-12    	54673003	       216.2 ns/op	     206 B/op	       5 allocs/op
```  