### PR TITLE
Line padding

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,10 +48,28 @@ snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+    - Merge remote-tracking branch
+    - Merge branch
+  groups:
+    - layout: post
+title: 'Features'
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - layout: post
+title: 'Fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 10
+    - layout: post
+title: Other work
+      order: 999
+  # sort: asc
+  # filters:
+  #   exclude:
+  #     - '^docs:'
+  #     - '^test:'
 
 brews:
   - name: scotty

--- a/app/bindings/bindings_test.go
+++ b/app/bindings/bindings_test.go
@@ -3,33 +3,12 @@ package bindings
 import (
 	"testing"
 
-	// "github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
-	// "github.com/kr/pretty"
 )
-
-// func TestSimpleSeqTree(t *testing.T) {
-//
-// 	m := NewMap()
-//
-// 	m.Bind("f").Action(func(km tea.KeyMsg) tea.Cmd {
-// 		return func() tea.Msg {
-// 			return "hello world"
-// 		}
-// 	})
-//
-// 	pretty.Print(m.binds["f"])
-// }
 
 func TestOptionSeqTree(t *testing.T) {
 
 	m := NewMap()
-
-	// m.Bind(" ").Option("f").Action(func(km tea.KeyMsg) tea.Cmd {
-	// 	return func() tea.Msg {
-	// 		return "called: SPC->f"
-	// 	}
-	// })
 
 	m.Bind(" ").Option("f").Action(func(km tea.KeyMsg) tea.Cmd {
 		return func() tea.Msg {

--- a/app/component/browsing/browsing.go
+++ b/app/component/browsing/browsing.go
@@ -142,9 +142,13 @@ func (model *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		model.prompt.Width = promptWidth
 
 		if !model.ready {
-			model.formatter.Reset(model.width, uint8(model.height))
 			model.ready = true
+			model.formatter.Reset(model.width, uint8(model.height))
+			break
 		}
+
+		model.formatter.Resize(model.width, uint8(model.height))
+
 	case tea.KeyMsg:
 		if model.bindings.Matches(msg) {
 			cmds = append(cmds, model.bindings.Exec(msg).Call(msg))

--- a/app/component/browsing/browsing.go
+++ b/app/component/browsing/browsing.go
@@ -87,6 +87,7 @@ func New(formatter store.Formatter) *Model {
 				if model.prompt.Focused() {
 					return nil
 				}
+				model.prompt.Reset()
 				model.prompt.Prompt = focusedPromptChar
 				return tea.Batch(model.prompt.Focus(), info.RequestMode(info.ModePromptActive))
 			},

--- a/app/component/welcome/welcome.go
+++ b/app/component/welcome/welcome.go
@@ -114,14 +114,6 @@ func (m *Model) View() string {
 		styles.SpaceBetween(betweenSmall, browseKeyActions, browseKeyBindings, "."),
 	)
 
-	// usageStderr := lipgloss.JoinVertical(lipgloss.Center,
-	// 	lipgloss.PlaceHorizontal(betweenMedium, lipgloss.Center, lipgloss.NewStyle().Render("Usage")),
-	// 	styles.SpaceBetween(betweenMedium, useageFormats[0:1], []string{".", "."}, "."),
-	// )
-	// usageStdout := lipgloss.JoinVertical(lipgloss.Center,
-	// 	lipgloss.PlaceHorizontal(betweenMedium, lipgloss.Center, lipgloss.NewStyle().Render("Usage")),
-	// 	styles.SpaceBetween(betweenMedium, useageFormats[1:], []string{".", "."}, "."),
-	// )
 	usageStderr := styles.SpaceBetween(betweenMedium, useageFormats[0:1], []string{".", "."}, ".")
 	usageStdout := styles.SpaceBetween(betweenMedium, useageFormats[1:], []string{".", "."}, ".")
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
+	"net/http/pprof"
 	"os"
 	"time"
 
@@ -43,6 +45,17 @@ func main() {
 	bubble := tea.NewProgram(ui,
 		tea.WithAltScreen(),
 	)
+
+	go func() {
+		mux := http.NewServeMux()
+
+		mux.HandleFunc("/debug/pprof/heap", pprof.Index)
+		server := &http.Server{
+			Addr:    ":8081",
+			Handler: mux,
+		}
+		server.ListenAndServe()
+	}()
 
 	if _, err := bubble.Run(); err != nil {
 		fmt.Printf("unable to start scotty: %v", err)

--- a/store/formatter.go
+++ b/store/formatter.go
@@ -208,6 +208,13 @@ func (formatter *Formatter) Reset(width int, height uint8) {
 	formatter.buffer = make([]ring.Item, formatter.size)
 }
 
+func (formatter *Formatter) Resize(width int, height uint8) {
+	formatter.ttyWidth = width
+	formatter.size = height
+
+	formatter.buildView()
+}
+
 func (formatter Formatter) String() string {
 
 	modalWidth, modalHeight := lipgloss.Width(formatter.foreground), lipgloss.Height(formatter.foreground)

--- a/store/formatter_test.go
+++ b/store/formatter_test.go
@@ -30,14 +30,14 @@ func TestBuildView(t *testing.T) {
 	formatted := formatter.String()
 
 	want := []string{
-		`>>>t╭────────────────────────────────────────╮..`,
-		`test│ test |                                 │..`,
-		`test│ {                                      │..`,
-		`test│   "hello": "world",                    │..`,
-		`test│   "index": 1,                          │..`,
-		`test│   "level": "debug"                     │..`,
-		`test│ }                                      │..`,
-		`test╰────────────────────────────────────────╯..`,
+		`[1]>╭────────────────────────────────────────╮..`,
+		`[2]t│ test |                                 │..`,
+		`[3]t│ {                                      │..`,
+		`[4]t│   "hello": "world",                    │..`,
+		`[5]t│   "index": 1,                          │..`,
+		`[6]t│   "level": "debug"                     │..`,
+		`[7]t│ }                                      │..`,
+		`[8]t╰────────────────────────────────────────╯..`,
 	}
 
 	for i, line := range strings.Split(formatted, "\n") {

--- a/store/line_manipulation.go
+++ b/store/line_manipulation.go
@@ -22,52 +22,51 @@ func buildLines(item ring.Item, width int, prefixOpts ...func(string) string) (i
 		prefix = opt(prefix)
 	}
 
-	return breaklines(
-		prefix+item.Raw[:item.DataPointer],
-		len(prefix)+ansi.PrintableRuneWidth(item.Raw[:item.DataPointer]),
-		// len(prefix)+len(item.Label)+3, // 3 => prefix format: [index]<ws>label<ws>|<ws> -> 3 for <ws>|<ws>
+	return breakInLines(
 		item.Raw[item.DataPointer:],
 		width,
+		prefix+item.Raw[:item.DataPointer],
+		len(prefix)+ansi.PrintableRuneWidth(item.Raw[:item.DataPointer]),
 		len(prefix),
 	)
 }
 
-func breaklines(prefix string, escapedPrefixLen int, line string, width int, padding int) (int, []string) {
-
-	firstLineWidth := width - escapedPrefixLen
+func breakInLines(lineData string, maxWidth int, linePrefix string, printablePrefixLen int, whitespaceIndent int) (int, []string) {
 
 	// base case:
 	// prefix and line fit in tty width
-	if escapedPrefixLen+len(line) <= width {
-		return 1, []string{prefix + line}
+	if printablePrefixLen+len(lineData) <= maxWidth {
+		return 1, []string{linePrefix + lineData}
 	}
 
 	// the first line item of the returned slice
 	// must start with the prefix at the beginng
-	var lines []string = []string{prefix + line[:firstLineWidth]}
+	var lines []string = []string{linePrefix + lineData[:(maxWidth-printablePrefixLen)]}
 	// 	=> []string{"some-prefix followed-by-the-line-of-as-much-as-we-can-write-in-the-left-over-space}
 
-	line = line[firstLineWidth:]
+	lineData = lineData[(maxWidth - printablePrefixLen):]
+	indentPrefix := strings.Repeat(" ", whitespaceIndent) + linePrefix[whitespaceIndent:]
 
-	if len(line)+escapedPrefixLen <= width {
-		return len(lines) + 1, append(lines, strings.Repeat(" ", padding)+prefix[padding:]+line)
+	if len(lineData)+printablePrefixLen <= maxWidth {
+		return len(lines) + 1, append(lines, indentPrefix+lineData)
 	}
 
-	for len(line) >= width {
+	for len(lineData) >= maxWidth {
 		// try to insert as much as we can (depends on the tty width)
 		// of the line to the slice of line
-		line = strings.Repeat(" ", padding) + prefix[padding:] + line
-		lines = append(lines, line[:width])
+		lineData = indentPrefix + lineData
+		lines = append(lines, lineData[:maxWidth])
 
 		// update line with what is leftover of the line
-		line = line[width:]
+		lineData = lineData[maxWidth:]
 
-		if len(line) <= width {
-			return len(lines) + 1, append(lines, strings.Repeat(" ", padding)+prefix[padding:]+line)
+		if len(lineData) <= maxWidth {
+			return len(lines) + 1, append(lines, indentPrefix+lineData)
 		}
 	}
 
 	return len(lines), lines
+
 }
 
 func clamp(a int) int {

--- a/store/line_manipulation_test.go
+++ b/store/line_manipulation_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/KonstantinGasser/scotty/store/ring"
 )
 
-func TestBreakLines(t *testing.T) {
+func TestBreakInLines(t *testing.T) {
 
 	tt := []struct {
 		name     string
@@ -34,7 +34,7 @@ func TestBreakLines(t *testing.T) {
 
 	for _, tc := range tt {
 		// var depth int = 1
-		depth, lines := breaklines(tc.prefix, 0, tc.line, tc.width, 0)
+		depth, lines := breakInLines(tc.prefix, 0, tc.line, tc.width, 0)
 
 		if depth != tc.depth {
 			t.Fatalf("[%s] expected depth of: %d; got depth: %d and lines:\n\t%q", tc.name, tc.depth, depth, lines)

--- a/store/line_manipulation_test.go
+++ b/store/line_manipulation_test.go
@@ -87,3 +87,18 @@ func TestBuildLines(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkBuildLines(b *testing.B) {
+
+	width := 75
+	item := ring.Item{
+		Label:       "hello-world",
+		DataPointer: 14,
+		Raw:         `hello-world | {"level":"warn","ts":1680212791.946584,"caller":"application/structred.go:39","msg":"caution this indicates X","index":998,"ts":1680212791.946579}`,
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buildLines(item, width)
+	}
+}

--- a/store/ring/buffer.go
+++ b/store/ring/buffer.go
@@ -130,7 +130,7 @@ func (buf *Buffer) HasData(index uint32) bool {
 		return false
 	}
 
-	return len(buf.data[index].Raw) > 0
+	return len(buf.data[buf.marshalIndex(index)].Raw) > 0
 }
 
 func (buf *Buffer) marshalIndex(absolute uint32) uint32 {

--- a/store/ring/buffer_test.go
+++ b/store/ring/buffer_test.go
@@ -199,7 +199,7 @@ func newFilledBuffer(size int, writes int, fn func(i int) string) *Buffer {
 			Raw: fn(i),
 		})
 	}
-	return &buf
+	return buf
 }
 
 func TestOffsetWrite(t *testing.T) {


### PR DESCRIPTION
Currently if a log line needs to be broken down into multiple lines due to the width of the terminal, the new line starts right at the beginning of the line leading to readability issues.

Proposed solution included in this PR:
indent the line as much as the index+prefix+spacing demand causing the data portion of the log line to line up under each other.

*Note*:
This is only a quick draft issues I see:
- non optimal way to add indent/prefix to new line currently using string concatenation
- parameter naming is wild and bend to get a quick PoC of the feature
- on-unsubscribe the max-label-length must be recomputed which is not working at the moment. 